### PR TITLE
Refactor TestConfigurationFilter and its usages

### DIFF
--- a/src/main/java/es/us/isa/restest/configuration/TestConfigurationFilter.java
+++ b/src/main/java/es/us/isa/restest/configuration/TestConfigurationFilter.java
@@ -1,7 +1,6 @@
 package es.us.isa.restest.configuration;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.*;
 
 import io.swagger.v3.oas.models.PathItem.HttpMethod;
 
@@ -14,79 +13,164 @@ import io.swagger.v3.oas.models.PathItem.HttpMethod;
  * POST...). (GET, POST...)
  */
 public class TestConfigurationFilter {
+	public static final String ALL_PATHS_WILDCARD = "*";
+	private final String path; // Path to test (null for all)
+	private final Set<HttpMethod> methods; // Methods to test
 
-	private String path = null; // Path to test (null for all)
-	private Collection<HttpMethod> methods; // Methods to test
-
-	public TestConfigurationFilter() {
-	}
-
-	public TestConfigurationFilter(String path, Collection<HttpMethod> methods) {
+	public TestConfigurationFilter(String path, Set<HttpMethod> methods) {
 		this.path = path;
-		this.methods = methods;
+		this.methods = Collections.unmodifiableSet(methods);
 	}
 
 	public String getPath() {
 		return path;
 	}
 
-	public void setPath(String path) {
-		this.path = path;
-	}
-
 	public Collection<HttpMethod> getMethods() {
 		return methods;
 	}
 
-	public void setMethods(Collection<HttpMethod> methods) {
-		this.methods = methods;
+	/**
+	 * Parses a text description of a filter into an {@link TestConfigurationFilter} instance.
+	 * <p>
+	 * A filter can be described by string of form
+	 * <pre>
+	 * FilterDescription = Path ":" Method["," Method]…
+	 *              Path = "*" | relative path to an individual endpoint
+	 *            Method = "get" | "post" | "put" | "patch" | "delete" | "all"
+	 * </pre>
+	 * Some examples:
+	 * <ol>
+	 *     <li>{@code *:all} — matches all paths and all methods</li>
+	 *     <li>{@code *:get,post,put,patch,delete} — same as {@code *:all}</li>
+	 *     <li>{@code /pets/get:get,post} — a filter matching path '/pet/get' and methods GET and POST</li>
+	 * </ol>
+	 *
+	 * Instances of this class are immutable
+	 * @param filterDescription description of a filter in specified format, e.g. {@code /search:get,post}, {@code *:all}
+	 * @return an instance of {@link TestConfigurationFilter}
+	 * @throws IllegalArgumentException when passed filter description is invalid
+	 */
+	public static TestConfigurationFilter parse(final String filterDescription) {
+		final String[] pathAndMethods = filterDescription.split(":");
+
+		if (pathAndMethods.length != 2) {
+			throw new IllegalArgumentException("Invalid format: a filter must be specified with the format 'path:HTTPMethod1,HTTPMethod2,...'");
+		}
+
+		final String path = pathAndMethods[0];
+		if (path.isBlank()) throw newInvalidFormatException(filterDescription);
+
+		final String methodsPart = pathAndMethods[1];
+		if (methodsPart.isBlank()) throw newInvalidFormatException(filterDescription);
+
+		final var filterBuilder = new Builder();
+		filterBuilder.setPath(path.trim());
+
+		for (String method : pathAndMethods[1].split(",")) {
+			switch (method.toLowerCase()) {
+				case "get":
+					filterBuilder.addGetMethod();
+					break;
+				case "post":
+					filterBuilder.addPostMethod();
+					break;
+				case "put":
+					filterBuilder.addPutMethod();
+					break;
+				case "patch":
+					filterBuilder.addPatchMethod();
+					break;
+				case "delete":
+					filterBuilder.addDeleteMethod();
+					break;
+				case "all":
+					filterBuilder.addAllMethods();
+					break;
+				default:
+					throw newInvalidFormatException(filterDescription);
+			}
+		}
+		return filterBuilder.build();
 	}
 
-	public void addGetMethod() {
-		if (methods == null)
-			methods = new ArrayList<>();
-
-		methods.add(HttpMethod.GET);
-
+	private static IllegalArgumentException newInvalidFormatException(String inputString) {
+		return new IllegalArgumentException(
+				String.format("'%s' has invalid format. A filter must be specified as 'path:method,method,…' " +
+						"or '*:method,method', e.g. '/hello:get', '*:get'. " +
+						"Valid methods are get, post, put, patch, delete, all.",
+						inputString)
+		);
 	}
 
-	public void addPostMethod() {
-		if (methods == null)
-			methods = new ArrayList<>();
+	/**
+	 * Returns a brand new {@link Builder}
+	 */
+	public static Builder builder() { return new Builder(); }
 
-		methods.add(HttpMethod.POST);
+	/**
+	 * Fluent {@link TestConfigurationFilter} builder
+	 * <p>
+	 * Example usage:
+	 * <pre>
+	 *     TestConfigurationFilter filter = TestConfigurationFilter.builder()
+	 *     		.setPath("/pet/list")
+	 *     		.addGetMethod()
+	 *     		.build();
+	 * </pre>
+	 */
+	public static class Builder {
+		private String path;
+		private final Set<HttpMethod> methods = new HashSet<>();
 
-	}
+		private Builder () {}
 
-	public void addPutMethod() {
-		if (methods == null)
-			methods = new ArrayList<>();
+		public TestConfigurationFilter build() {
+			if (methods.isEmpty())
+				throw new IllegalArgumentException("No method was set to filter! You must specify at least one method for a filter");
 
-		methods.add(HttpMethod.PUT);
+			return new TestConfigurationFilter(this.path, this.methods);
+		}
 
-	}
+		public Builder setPath(String path) {
+			Objects.requireNonNull(path, "Path must not be empty");
+			if (path.isBlank()) throw new IllegalArgumentException("Path must not be blank");
+			this.path = ALL_PATHS_WILDCARD.equals(path) ? null : path;
+			return this;
+		}
 
-	public void addPatchMethod() {
-		if (methods == null)
-			methods = new ArrayList<>();
+		public Builder addGetMethod() {
+			this.methods.add(HttpMethod.GET);
+			return this;
+		}
 
-		methods.add(HttpMethod.PATCH);
+		public Builder addPostMethod() {
+			this.methods.add(HttpMethod.POST);
+			return this;
+		}
 
-	}
+		public Builder addPutMethod() {
+			this.methods.add(HttpMethod.PUT);
+			return this;
+		}
 
-	public void addDeleteMethod() {
-		if (methods == null)
-			methods = new ArrayList<>();
+		public Builder addPatchMethod() {
+			this.methods.add(HttpMethod.PATCH);
+			return this;
+		}
 
-		methods.add(HttpMethod.DELETE);
+		public Builder addDeleteMethod() {
+			this.methods.add(HttpMethod.DELETE);
+			return this;
+		}
 
-	}
-
-	public void addAllMethods() {
-		this.addGetMethod();
-		this.addPostMethod();
-		this.addPutMethod();
-		this.addPatchMethod();
-		this.addDeleteMethod();
+		public Builder addAllMethods() {
+			return this
+					.addGetMethod()
+					.addPostMethod()
+					.addPutMethod()
+					.addPatchMethod()
+					.addDeleteMethod();
+		}
 	}
 }

--- a/src/main/java/es/us/isa/restest/configuration/generators/DefaultTestConfigurationGenerator.java
+++ b/src/main/java/es/us/isa/restest/configuration/generators/DefaultTestConfigurationGenerator.java
@@ -79,9 +79,7 @@ public class DefaultTestConfigurationGenerator {
 	 * @return a test configuration object
 	 */
 	public TestConfigurationObject generate(String destination) {
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);
-		filter.addAllMethods();
+		TestConfigurationFilter filter = TestConfigurationFilter.parse("*:all");
 		return this.generate(destination, Collections.singletonList(filter));
 	}
 

--- a/src/main/java/es/us/isa/restest/examples/Ex2_CreateTestConf.java
+++ b/src/main/java/es/us/isa/restest/examples/Ex2_CreateTestConf.java
@@ -2,19 +2,12 @@ package es.us.isa.restest.examples;
 
 import es.us.isa.restest.configuration.TestConfigurationFilter;
 import es.us.isa.restest.configuration.generators.DefaultTestConfigurationGenerator;
-import es.us.isa.restest.generators.RandomTestCaseGenerator;
-import es.us.isa.restest.runners.RESTestLoader;
 import es.us.isa.restest.specification.OpenAPISpecification;
-import es.us.isa.restest.testcases.TestCase;
 import es.us.isa.restest.util.RESTestException;
-import es.us.isa.restest.writers.restassured.RESTAssuredWriter;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
-import static es.us.isa.restest.util.FileManager.checkIfExists;
-import static es.us.isa.restest.util.FileManager.deleteFile;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -38,9 +31,7 @@ public class Ex2_CreateTestConf {
 
         // Create filters to indicate which operations (paths and http methods) to include in the test configuration file.
         List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-        TestConfigurationFilter filter = new TestConfigurationFilter();
-        filter.setPath("/recipes");
-        filter.addGetMethod();
+        TestConfigurationFilter filter = TestConfigurationFilter.parse("/recipes:get");
         filters.add(filter);
 
         // Generate default test configuration file

--- a/src/main/java/es/us/isa/restest/generators/AbstractTestCaseGenerator.java
+++ b/src/main/java/es/us/isa/restest/generators/AbstractTestCaseGenerator.java
@@ -183,31 +183,13 @@ public abstract class AbstractTestCaseGenerator {
 			int filterIndex = -1;
 
 			if(filter == null) {
-				filter = new TestConfigurationFilter();
-				filter.setPath(testOperation.getTestPath());
+				filter = TestConfigurationFilter.parse(
+						Objects.requireNonNullElse(testOperation.getTestPath(), "*") +
+								":" +
+								testOperation.getMethod().toLowerCase()
+				);
 			} else {
 				filterIndex = filters.indexOf(filter);
-			}
-
-			switch(testOperation.getMethod().toLowerCase()) {
-				case "get":
-					filter.addGetMethod();
-					break;
-				case "post":
-					filter.addPostMethod();
-					break;
-				case "put":
-					filter.addPutMethod();
-					break;
-				case "patch":
-					filter.addPatchMethod();
-					break;
-				case "delete":
-					filter.addDeleteMethod();
-					break;
-				default:
-					throw new RESTestException("Methods other than GET, POST, PUT, PATCH and DELETE are not " +
-							"allowed in the test configuration file");
 			}
 
 			if(filterIndex > -1) {

--- a/src/main/java/es/us/isa/restest/main/CreateTestConf.java
+++ b/src/main/java/es/us/isa/restest/main/CreateTestConf.java
@@ -64,48 +64,9 @@ public class CreateTestConf {
      * Each filter must follow the format "path:httpmethod".
      */
     private static List<TestConfigurationFilter> generateFilters(String[] filtersArr) {
-        List<TestConfigurationFilter> filters = new ArrayList<>();
-
-        for(String s : filtersArr) {
-            TestConfigurationFilter filter = new TestConfigurationFilter();
-            String[] sp = s.split(":");
-
-            if(sp.length != 2) {
-                throw new IllegalArgumentException("Invalid format: a filter must be specified with the format 'path:HTTPMethod1,HTTPMethod2,...'");
-            }
-
-            filter.setPath(sp[0]);
-            String[] methods = sp[1].split(",");
-
-            for(String method : methods) {
-                switch (method.toLowerCase()) {
-                    case "get":
-                        filter.addGetMethod();
-                        break;
-                    case "post":
-                        filter.addPostMethod();
-                        break;
-                    case "put":
-                        filter.addPutMethod();
-                        break;
-                    case "patch":
-                        filter.addPatchMethod();
-                        break;
-                    case "delete":
-                        filter.addDeleteMethod();
-                        break;
-                    case "all":
-                        filter.addAllMethods();
-                        break;
-                    default:
-                        throw new IllegalArgumentException("HTTP method not supported: " + method);
-                }
-            }
-
-            filters.add(filter);
-        }
-
-        return filters;
+        return Arrays.stream(filtersArr)
+                .map(TestConfigurationFilter::parse)
+                .collect(Collectors.toList());
     }
 
     /*

--- a/src/test/java/es/us/isa/restest/configuration/TestConfigurationFilterTest.java
+++ b/src/test/java/es/us/isa/restest/configuration/TestConfigurationFilterTest.java
@@ -1,0 +1,123 @@
+package es.us.isa.restest.configuration;
+
+import io.swagger.v3.oas.models.PathItem.HttpMethod;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+class TestConfigurationFilterTest {
+
+    /**
+     * Here we make sure that when we try to parse a filter description with non-wildcard path and each supported method
+     * we get no errors and a TestConfigurationFilter containing all required methods.
+     *
+     * Non-wildcard path is a valid path to an endpoint, like /search, /pet/list, etc.
+     */
+    @DisplayName("All methods in filter descriptions are parsed correctly when path is not a wildcard")
+    @ParameterizedTest
+    @MethodSource("methods")
+    public void parsesAllMethodsWhenPathIsNotWildcard(String methodDescription, List<HttpMethod> expectedHttpMethods) {
+        final var filterDescription = "/path:" + methodDescription;
+
+        final TestConfigurationFilter filter = Assertions.assertDoesNotThrow(
+                () -> TestConfigurationFilter.parse(filterDescription),
+                "An unexpected exception was thrown while parsing '" + filterDescription + "'");
+
+        Assertions.assertEquals(expectedHttpMethods.size(), filter.getMethods().size());
+        expectedHttpMethods.forEach(
+                expectedMethod -> Assertions.assertTrue(
+                        filter.getMethods().contains(expectedMethod),
+                        String.format("After parsing '%s' filter must contain method %s, but it doesn't!",
+                                filterDescription, expectedMethod)
+                )
+        );
+    }
+
+    /**
+     * Here we make sure that when we try to parse a filter description with wildcard path and each supported method
+     * we get no errors and a TestConfigurationFilter containing all required methods.
+     *
+     * A wildcard path is a path description that matches any path
+     */
+    @DisplayName("All methods in filter descriptions are parsed correctly when path is a wildcard")
+    @ParameterizedTest
+    @MethodSource("methods")
+    public void parsesAllMethodsWhenPathIsWildcard(String methodDescription, List<HttpMethod> expectedHttpMethods) {
+        final var filterDescription = TestConfigurationFilter.ALL_PATHS_WILDCARD + ":" + methodDescription;
+
+        final TestConfigurationFilter filter = Assertions.assertDoesNotThrow(
+                () -> TestConfigurationFilter.parse(filterDescription),
+        "An unexpected exception was thrown while parsing '" + filterDescription + "'");
+
+        Assertions.assertEquals(expectedHttpMethods.size(), filter.getMethods().size());
+        expectedHttpMethods.forEach(
+                expectedMethod -> Assertions.assertTrue(
+                        filter.getMethods().contains(expectedMethod),
+                        String.format("After parsing '%s' filter must contain method %s, but it doesn't!",
+                                filterDescription, expectedMethod)
+                )
+        );
+    }
+
+    static Stream<Arguments> methods() {
+        return Stream.of(
+                Arguments.of("get",    List.of(HttpMethod.GET)),
+                Arguments.of("post",   List.of(HttpMethod.POST)),
+                Arguments.of("put",    List.of(HttpMethod.PUT)),
+                Arguments.of("patch",  List.of(HttpMethod.PATCH)),
+                Arguments.of("delete", List.of(HttpMethod.DELETE)),
+                Arguments.of("all",    List.of(HttpMethod.GET,
+                                                         HttpMethod.POST,
+                                                         HttpMethod.PUT,
+                                                         HttpMethod.PATCH,
+                                                         HttpMethod.DELETE))
+        );
+    }
+
+    @DisplayName("Parsing fails when filter description has invalid format")
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "", "  ",
+            ":", " : ",
+            "/path:",
+            ":get",
+            "/path:get,hello",
+            "/path:get:get"
+    })
+    public void assertInvalidFormatThrows(String filterDescription) {
+        Assertions.assertThrows(Exception.class, () -> TestConfigurationFilter.parse(filterDescription),
+                "An exception was expected to be thrown while parsing '" + filterDescription + "'");
+    }
+
+    /**
+     * When we parse a filter description with wildcard path the resulting filter has to have null in its 'path' field.
+     */
+    @DisplayName("Wildcard path is parsed into null")
+    @Test
+    public void assertWildcardPathLeadsToNullPath() {
+        final var filterDescription = TestConfigurationFilter.ALL_PATHS_WILDCARD + ":all";
+        Assertions.assertNull(
+                TestConfigurationFilter.parse(filterDescription).getPath(),
+                "A path was expected to be null after parsing " + filterDescription
+        );
+    }
+
+    /**
+     * When we parse a filter description with non-wildcard path then resulting filter has to have the exact same path,
+     * but with all leading and trailing spaces removed.
+     */
+    @DisplayName("Non-wildcard is trimmed and then taken as is")
+    @ParameterizedTest
+    @ValueSource(strings = {"  /path  ", "/path"})
+    public void assertNonWildcardIsParsedCorrectly(String path) {
+        final var filterDescription = path + ":all";
+        Assertions.assertEquals(path.trim(), TestConfigurationFilter.parse(filterDescription).getPath());
+    }
+}

--- a/src/test/java/es/us/isa/restest/configuration/generators/DefaultTestConfigurationGeneratorTest.java
+++ b/src/test/java/es/us/isa/restest/configuration/generators/DefaultTestConfigurationGeneratorTest.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.junit.Test;
 
 import es.us.isa.restest.configuration.TestConfigurationFilter;
-import es.us.isa.restest.configuration.generators.DefaultTestConfigurationGenerator;
 import es.us.isa.restest.specification.OpenAPISpecification;
 
 import static es.us.isa.restest.util.FileManager.checkIfExists;
@@ -21,12 +20,10 @@ public class DefaultTestConfigurationGeneratorTest {
 		String specPath="src/test/resources/BigOven/spec.yaml";
 		String confPath="src/test/resources/BigOven/defaultConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
-		
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath("/recipes");
-		filter.addGetMethod();
-		filters.add(filter);
+
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/recipes:get")
+		);
 		
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -75,11 +72,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Amadeus/defaultConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 		
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath("/hotels/search-airport");
-		filter.addGetMethod();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/hotels/search-airport:get")
+		);
 		
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -94,11 +89,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/AmadeusHotel/defaultConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -113,11 +106,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Playlist/defaultConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 		
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 		
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -132,11 +123,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Amadeus/fullConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -151,11 +140,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Petstore/fullConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -170,11 +157,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/SimpleAPI/fullConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -189,11 +174,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Bikewise/fullConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -208,11 +191,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/DataAtWork/fullConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -227,31 +208,11 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/YouTube/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-//		TestConfigurationFilter filter = new TestConfigurationFilter();
-//		filter.setPath(null);
-//		filter.addAllMethods();
-//		filters.add(filter);
-
-		// Filter 1
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath("/activities");
-		filter.addGetMethod();
-		filter.addPostMethod();
-		filters.add(filter);
-
-		// Filter 2
-		TestConfigurationFilter filter2 = new TestConfigurationFilter();
-		filter2.setPath("/search");
-		filter2.addGetMethod();
-		filters.add(filter2);
-
-		// Filter 3
-		TestConfigurationFilter filter3 = new TestConfigurationFilter();
-		filter3.setPath("/videos");
-		filter3.addGetMethod();
-		filter3.addPostMethod();
-		filters.add(filter3);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/activities:get,post"),
+				TestConfigurationFilter.parse("/search:get"),
+				TestConfigurationFilter.parse("/videos:get,post")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -266,11 +227,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Comments/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -285,11 +244,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Comments/testConf_forTestSuite2_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -304,11 +261,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Events/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -323,11 +278,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Travel/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -342,13 +295,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/YouTube/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-
-		// Filter 1
-		TestConfigurationFilter filter2 = new TestConfigurationFilter();
-		filter2.setPath("/search");
-		filter2.addGetMethod();
-		filters.add(filter2);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/search:get")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -363,11 +312,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/OMDb/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -382,11 +329,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Memes/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -401,11 +346,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Marvel/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -420,11 +363,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Twitter/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -439,11 +380,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Foursquare/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -458,11 +397,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/BingWebSearch/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -477,11 +414,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Tumblr/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -496,11 +431,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/Stripe/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -514,11 +447,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/AnApiOfIceAndFire/testConf_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);
@@ -532,11 +463,9 @@ public class DefaultTestConfigurationGeneratorTest {
 		String confPath="src/test/resources/restest-test-resources/testConf-scout_test.yaml";
 		OpenAPISpecification spec = new OpenAPISpecification(specPath);
 
-		List<TestConfigurationFilter> filters = new ArrayList<TestConfigurationFilter>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath(null);		// null = All paths
-		filter.addAllMethods();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("*:all")
+		);
 
 		DefaultTestConfigurationGenerator gen = new DefaultTestConfigurationGenerator(spec);
 		gen.generate(confPath, filters);

--- a/src/test/java/es/us/isa/restest/generators/ConstraintBasedTestCaseGeneratorTest.java
+++ b/src/test/java/es/us/isa/restest/generators/ConstraintBasedTestCaseGeneratorTest.java
@@ -312,11 +312,9 @@ public class ConstraintBasedTestCaseGeneratorTest {
 		AbstractTestCaseGenerator generator = new ConstraintBasedTestCaseGenerator(spec, conf, numTestCases);
 		generator.setFaultyRatio(faultyRatio);
 
-		List<TestConfigurationFilter> filters = new ArrayList<>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath("/artists");
-		filter.addGetMethod();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/artists:get")
+		);
 
 		Collection<TestCase> testCases = generator.generate(filters);
 
@@ -575,13 +573,10 @@ public class ConstraintBasedTestCaseGeneratorTest {
 		generator.setFaultyDependencyRatio(faultyDependencyRatio);
 		generator.setFaultyRatio(faultyRatio);
 
-		
-		List<TestConfigurationFilter> filters = new ArrayList<>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath("/comments");
-		filter.addGetMethod();
-		filters.add(filter);
-		
+
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/comments:get")
+		);
 		
 		Collection<TestCase> testCases = generator.generate(filters);
 		

--- a/src/test/java/es/us/isa/restest/generators/RandomTestCaseGeneratorTest.java
+++ b/src/test/java/es/us/isa/restest/generators/RandomTestCaseGeneratorTest.java
@@ -39,32 +39,13 @@ public class RandomTestCaseGeneratorTest {
 		// Create generator and filter
 		AbstractTestCaseGenerator generator = new RandomTestCaseGenerator(spec, conf, numTestCases);
 
-		List<TestConfigurationFilter> filters = new ArrayList<>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath("/store/order/{orderId}");
-		filter.addGetMethod();
-		filters.add(filter);
-
-		TestConfigurationFilter filter2 = new TestConfigurationFilter();
-		filter2.setPath("/user/login");
-		filter2.addGetMethod();
-		filters.add(filter2);
-
-		TestConfigurationFilter filter3 = new TestConfigurationFilter();
-		filter3.setPath("/pet");
-		filter3.addPostMethod();
-		filter3.addPutMethod();
-		filters.add(filter3);
-
-		TestConfigurationFilter filter4 = new TestConfigurationFilter();
-		filter4.setPath("/store/order");
-		filter4.addPostMethod();
-		filters.add(filter4);
-
-		TestConfigurationFilter filter5 = new TestConfigurationFilter();
-		filter5.setPath("/user");
-		filter5.addPostMethod();
-		filters.add(filter5);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/store/order/{orderId}:get"),
+				TestConfigurationFilter.parse("/user/login:get"),
+				TestConfigurationFilter.parse("/pet:post,put"),
+				TestConfigurationFilter.parse("/store/order:post"),
+				TestConfigurationFilter.parse("/user:post")
+		);
 
 		Collection<TestCase> testCases = generator.generate(filters);
 
@@ -112,32 +93,13 @@ public class RandomTestCaseGeneratorTest {
 		AbstractTestCaseGenerator generator = new RandomTestCaseGenerator(spec, conf, numTestCases);
 		generator.setFaultyRatio(faultyRatio);
 
-		List<TestConfigurationFilter> filters = new ArrayList<>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath("/store/order/{orderId}");
-		filter.addGetMethod();
-		filters.add(filter);
-
-		TestConfigurationFilter filter2 = new TestConfigurationFilter();
-		filter2.setPath("/user/login");
-		filter2.addGetMethod();
-		filters.add(filter2);
-
-		TestConfigurationFilter filter3 = new TestConfigurationFilter();
-		filter3.setPath("/pet");
-		filter3.addPostMethod();
-		filter3.addPutMethod();
-		filters.add(filter3);
-
-		TestConfigurationFilter filter4 = new TestConfigurationFilter();
-		filter4.setPath("/store/order");
-		filter4.addPostMethod();
-		filters.add(filter4);
-
-		TestConfigurationFilter filter5 = new TestConfigurationFilter();
-		filter5.setPath("/user");
-		filter5.addPostMethod();
-		filters.add(filter5);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/store/order/{orderId}:get"),
+				TestConfigurationFilter.parse("/user/login:get"),
+				TestConfigurationFilter.parse("/pet:post,put"),
+				TestConfigurationFilter.parse("/store/order:post"),
+				TestConfigurationFilter.parse("/user:post")
+		);
 
 		Collection<TestCase> testCases = generator.generate(filters);
 
@@ -425,11 +387,9 @@ public class RandomTestCaseGeneratorTest {
 		// Create generator and filter
 		AbstractTestCaseGenerator generator = new RandomTestCaseGenerator(spec, conf, numTestCases);
 
-		List<TestConfigurationFilter> filters = new ArrayList<>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath("/hotels/search-airport");
-		filter.addGetMethod();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/hotels/search-airport:get")
+		);
 
 		Collection<TestCase> testCases = generator.generate(filters);
 
@@ -475,11 +435,9 @@ public class RandomTestCaseGeneratorTest {
 		// Create generator and filter
 		AbstractTestCaseGenerator generator = new RandomTestCaseGenerator(spec, conf, numTestCases);
 
-		List<TestConfigurationFilter> filters = new ArrayList<>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath("/albums");
-		filter.addGetMethod();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/albums:get")
+		);
 
 		Collection<TestCase> testCases = generator.generate(filters);
 
@@ -518,11 +476,9 @@ public class RandomTestCaseGeneratorTest {
 		// Create generator and filter
 		AbstractTestCaseGenerator generator = new RandomTestCaseGenerator(spec, conf, numTestCases);
 
-		List<TestConfigurationFilter> filters = new ArrayList<>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath("/artists");
-		filter.addGetMethod();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/hotels/artists:get")
+		);
 
 		Collection<TestCase> testCases = generator.generate(filters);
 
@@ -557,11 +513,9 @@ public class RandomTestCaseGeneratorTest {
 		// Create generator and filter
 		AbstractTestCaseGenerator generator = new RandomTestCaseGenerator(spec, conf, numTestCases);
 
-		List<TestConfigurationFilter> filters = new ArrayList<>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath("/search");
-		filter.addGetMethod();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/search:get")
+		);
 
 		Collection<TestCase> testCases = generator.generate(filters);
 
@@ -607,11 +561,9 @@ public class RandomTestCaseGeneratorTest {
 		AbstractTestCaseGenerator generator = new RandomTestCaseGenerator(spec, conf, numTestCases);
 		generator.setFaultyRatio(faultyRatio);
 
-		List<TestConfigurationFilter> filters = new ArrayList<>();
-		TestConfigurationFilter filter = new TestConfigurationFilter();
-		filter.setPath("/artists");
-		filter.addGetMethod();
-		filters.add(filter);
+		List<TestConfigurationFilter> filters = List.of(
+				TestConfigurationFilter.parse("/artists:get")
+		);
 
 		Collection<TestCase> testCases = generator.generate(filters);
 


### PR DESCRIPTION
In short this commit
- Adds a method which creates a new filter by parsing a string
- Adds a builder to enable creating filters in fluent-style
- Makes TestConfigurationFilter object immutable after creation

In many places handling of TestConfigurationFilter looked a bit clumsy to me: first create an object, then look at HTTP method names, then set the filter's fields. In order to make working with filters more elegant, the logic of creating filters is now hidden in one method, which takes a string and returns a filter.

This change allowed to make filter objects immutable, which is almost always a good thing: the less the state changes, the less you have to think about it.