### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ mvn clean install -DskipTests
 Then, run the JAR file passing as argument the path to the properties file, for example:
 
 ```
-java -jar target/restest-full.jar src/test/resources/Restcountries/restcountries_demo.properties
+java -jar target/restest.jar src/test/resources/Restcountries/restcountries_demo.properties
 ```
 
 ### Option 2: Download the latest release


### PR DESCRIPTION
This pull request fixes a typographical error in the project's README file. The name of generated JAR file to run RESTest is incorrectly spelled as ```restest-full.jar```, and should be corrected to ```restest.jar``` to reflect the correct JAR file name. This change will ensure that users get accurate information and will be able to use the JAR correctly.