### PR TITLE
Add new constructors for RESTestLoader and RESTestExecutor classes

### DIFF
--- a/src/main/java/es/us/isa/restest/runners/RESTestExecutor.java
+++ b/src/main/java/es/us/isa/restest/runners/RESTestExecutor.java
@@ -33,6 +33,10 @@ public class RESTestExecutor {
         loader = new RESTestLoader(propertyFilePath);
     }
 
+    public RESTestExecutor(String propertyFilePath, boolean reloadProperties) {
+        loader = new RESTestLoader(propertyFilePath, reloadProperties);
+    }
+
     public void execute() {
         String filePath = loader.targetDirJava + "/" + loader.testClassName + ".java";
         String className = loader.packageName + "." + loader.testClassName;

--- a/src/main/java/es/us/isa/restest/runners/RESTestLoader.java
+++ b/src/main/java/es/us/isa/restest/runners/RESTestLoader.java
@@ -72,6 +72,14 @@ public class RESTestLoader {
 		readProperties();
 	}
 
+	public RESTestLoader(String userPropertiesFilePath, boolean reloadProperties) {
+		if (reloadProperties) {
+			PropertyManager.setUserPropertiesFilePath(null);
+		}
+		this.userPropertiesFilePath = userPropertiesFilePath;
+		readProperties();
+	}
+
 	public RESTestLoader() {
 		readProperties();
 	}

--- a/src/main/java/es/us/isa/restest/util/PropertyManager.java
+++ b/src/main/java/es/us/isa/restest/util/PropertyManager.java
@@ -61,5 +61,10 @@ public class PropertyManager {
 		return userProperties.getProperty(name);
 	}
 
+	// Setters
+
+	public static void setUserPropertiesFilePath(Properties userPropertiesFilePath) {
+		userProperties = userPropertiesFilePath;
+	}
 
 }


### PR DESCRIPTION
Currently RESTest has a problem if a user wants to initialize different `RESTestLoader` instances in the same execution, for example, to generate test cases associated to the same API but using different test case generators. I show it in an example.

Imagine that you want to perform an execution in which tests are generated with the `RandomTestCaseGenerator` and `ConstraintBasedTestCaseGenerator` classes. The normal thing would be to think of executing the following code:

```java
// RT Generation
RESTestLoader loaderRT = new RESTestLoader(RT_PROPERTY_FILE_PATH);

RandomTestCaseGenerator generatorRT = (RandomTestCaseGenerator) loaderRT.createGenerator();
Collection<TestCase> testCasesRT = generatorRT.generate();

createDir(loaderRT.getTargetDirJava());

RESTAssuredWriter writerRT = (RESTAssuredWriter) loaderRT.createWriter();
writerRT.write(testCasesRT);

logger.info(testCasesRT.size() + " test cases generated and written to " + loaderRT.getTargetDirJava());

// CBT Generation
RESTestLoader loaderCBT = new RESTestLoader(CBT_PROPERTY_FILE_PATH);

ConstraintBasedTestCaseGenerator generator = (ConstraintBasedTestCaseGenerator) loaderCBT.createGenerator();
Collection<TestCase> testCasesCBT = generator.generate();

createDir(loaderCBT.getTargetDirJava());

RESTAssuredWriter writerCBT = (RESTAssuredWriter) loaderCBT.createWriter();
writerCBT.write(testCasesCBT);

logger.info(testCasesCBT.size() + " test cases generated and written to " + loaderCBT.getTargetDirJava());
```

The mentioned _loader_ problem occurs exactly in the operation `new RESTestLoader(CBT_PROPERTY_FILE_PATH);`. As the properties file associated to the RT generator has been previously loaded in the `RESTestLoader` class, when "trying" to load the properties of the CBT generator, the attributes of the loader are not overwritten, and therefore, for the second generation it would still use RT, among other incorrect data.

With the changes made, the user could now indicate whether to reset the properties when initializing the new _loader_, as follows:

```java
RESTestLoader loaderCBT = new RESTestLoader(CBT_PROPERTY_FILE_PATH, true);
```

The problem occurred in the same way with the `RESTestestExecutor` class, since it makes use of the `RESTestestLoader` class in its constructor. If a user wanted to execute, in the same run, the test cases that it has generated, it should be done in the following way:

```java
RESTestExecutor executorRT = new RESTestExecutor(RT_PROPERTY_FILE_PATH);
executorRT.execute();

RESTestExecutor executorCBT = new RESTestExecutor(CBT_PROPERTY_FILE_PATH, true);
executorCBT.execute();
```