### PR TITLE
Fix Allure results directory when using RESTestRunner

### DIFF
--- a/src/main/java/es/us/isa/restest/runners/RESTestExecutor.java
+++ b/src/main/java/es/us/isa/restest/runners/RESTestExecutor.java
@@ -5,6 +5,8 @@ import es.us.isa.restest.specification.OpenAPISpecification;
 import es.us.isa.restest.util.ClassLoader;
 
 import es.us.isa.restest.util.Timer;
+import io.qameta.allure.AllureLifecycle;
+import io.qameta.allure.junit4.AllureJunit4;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.runner.JUnitCore;
@@ -28,6 +30,7 @@ public class RESTestExecutor {
     private static final Logger logger = LogManager.getLogger(RESTestExecutor.class.getName());
 
     RESTestLoader loader;
+    private final AllureLifecycle allureLifecycle = new AllureLifecycle();
 
     public RESTestExecutor(String propertyFilePath) {
         loader = new RESTestLoader(propertyFilePath);
@@ -45,6 +48,8 @@ public class RESTestExecutor {
             logger.error("Test class {} not found in {}", className, filePath);
             throw new IllegalArgumentException("Test class " + className + " not found in " + filePath);
         }else{
+            String allureResultsDirectory = loader.allureResultsPath + "/" + loader.experimentName;
+            System.setProperty("allure.results.directory", allureResultsDirectory);
             Class<?> testClass = loadTestClass(filePath, className);
             runTests(testClass);
         }
@@ -59,7 +64,7 @@ public class RESTestExecutor {
     private void runTests(Class<?> testClass) {
 
         JUnitCore junit = new JUnitCore();
-        junit.addListener(new io.qameta.allure.junit4.AllureJunit4());
+        junit.addListener(new AllureJunit4(this.allureLifecycle));
         loader.spec = new OpenAPISpecification(loader.OAISpecPath);
         loader.createStatsReportManager();
         Timer.startCounting(TEST_SUITE_EXECUTION);

--- a/src/main/java/es/us/isa/restest/runners/RESTestLoader.java
+++ b/src/main/java/es/us/isa/restest/runners/RESTestLoader.java
@@ -51,6 +51,7 @@ public class RESTestLoader {
 	Boolean logToFile;									// If 'true', log messages will be printed to external files
 	Boolean executeTestCases;							// If 'false', test cases will be generated but not executed
 	Boolean allureReports;								// If 'true', Allure reports will be generated
+	String allureResultsPath;							// Path to Allure results
 	String allureReportsPath;							// Path to Allure reports
 	Boolean checkTestCases;								// If 'true', test cases will be checked with OASValidator before executing them
 	String proxy;										// Proxy to use for all requests in format host:port
@@ -146,7 +147,7 @@ public class RESTestLoader {
 	public AllureReportManager createAllureReportManager() {
 		AllureReportManager arm = null;
 		if(executeTestCases) {
-			String allureResultsDir = readProperty("allure.results.dir") + "/" + experimentName;
+			String allureResultsDir = allureResultsPath + "/" + experimentName;
 			String allureReportDir = allureReportsPath + "/" + experimentName;
 
 			// Delete previous results (if any)
@@ -221,6 +222,8 @@ public class RESTestLoader {
 		}
 		logger.info("Allure reports: {}", allureReports);
 
+		allureResultsPath = readProperty("allure.results.dir");
+		logger.info("Allure results path: {}", allureResultsPath);
 
 		allureReportsPath = readProperty("allure.report.dir");
 		logger.info("Allure reports path: {}", allureReportsPath);


### PR DESCRIPTION
RESTestLoader#createAllureReportManager() changes the default Allure results directory to a dedicated subdirectory for the experiment. However, RESTestRunner does not use that method, leading to inconsistent behavior and a directory with mixed results when running multiple experiments.

Solving this by overriding the `allure.results.directory` system property before running the tests.