### PR TITLE
Ensure that tests and coverage directories exist

### DIFF
--- a/src/main/java/es/us/isa/restest/runners/RESTestLoader.java
+++ b/src/main/java/es/us/isa/restest/runners/RESTestLoader.java
@@ -174,11 +174,11 @@ public class RESTestLoader {
 		if (deletePreviousResults) {
 			deleteDir(testDataDir);
 			deleteDir(coverageDataDir);
-
-			// Recreate directories
-			createDir(testDataDir);
-			createDir(coverageDataDir);
 		}
+
+    // Create target directories if they don't exist
+		createDir(testDataDir);
+		createDir(coverageDataDir);
 
 		CoverageMeter coverageMeter = enableInputCoverage || enableOutputCoverage ? new CoverageMeter(new CoverageGatherer(spec)) : null;
 


### PR DESCRIPTION
Create `data.tests.dir` and `data.coverage.dir` directories if they don't exist.