### PR TITLE
Break an architectural rule and the build says so, by name and line

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Line endings, kept deliberately narrow.
+#
+# There is no blanket "* text=auto" here on purpose. This repository already carries the 1.x test
+# corpus, and at least one tracked fixture is stored with CRLF in the index; a blanket rule would
+# mark it unnormalised, so the next person to run "git add -A" near it would silently commit a
+# whole-file line-ending change to a file they never opened. The four rules below are all the
+# Windows CI rows actually need.
+
+# mvnw is executed by /bin/sh, including by Git Bash on the Windows runners. A CRLF checkout turns
+# the shebang into "/bin/sh^M" and the build dies with "bad interpreter".
+mvnw text eol=lf
+*.sh text eol=lf
+
+# Batch files are executed by cmd.exe, which wants CRLF.
+mvnw.cmd text eol=crlf
+*.bat text eol=crlf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependency updates arrive as reviewable pull requests rather than as drift.
+#
+# Grouped on purpose: nine modules share one version property per dependency, so an ungrouped
+# update would open several pull requests that all have to land together anyway.
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+      include: scope
+    groups:
+      test-libraries:
+        patterns:
+          - org.junit*
+          - org.assertj*
+          - com.tngtech.archunit*
+          - org.testcontainers*
+          - org.wiremock*
+      build-plugins:
+        patterns:
+          - org.apache.maven.plugins*
+          - org.jacoco*
+          - org.pitest*
+
+  # Keeps the commit-SHA pins in .github/workflows current. Dependabot rewrites both the SHA and
+  # the trailing version comment, which is why that comment is required rather than decorative.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+# Continuous integration for RESTest 2.0.
+#
+# Three operating systems x Java 21, 25 and 26, every row building and testing the whole reactor
+# (ADR-0003). Every action is pinned to a commit SHA rather than a tag: a tag can be repointed at
+# any commit by whoever owns the action, a SHA cannot. The trailing comment is what lets Dependabot
+# recognise and bump the pin, and SourceTreeRulesTest fails the build if a pin regresses to a tag.
+name: CI
+
+on:
+  push:
+    branches: [master, v2]
+  pull_request:
+    branches: [master, v2]
+  workflow_dispatch:
+
+# A new push supersedes the runs still queued for the same ref.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+# Windows runners default to PowerShell, which cannot execute mvnw: it is a POSIX shell script with
+# no extension, so CreateProcess rejects it outright. Git Bash is present on every runner image, so
+# one default makes the same command work on all three operating systems.
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Java ${{ matrix.java }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # One red row must not hide the state of the other eight.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        java: ['21', '25', '26']
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@de7274f081f381c8f8158605e0321c36c376e2e6 # v6.0.1
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: maven
+
+      - name: Build and test
+        run: ./mvnw --batch-mode --no-transfer-progress verify
+
+      # Uploaded from one row only: nine identical reports would be noise.
+      - name: Upload the coverage report
+        if: matrix.os == 'ubuntu-latest' && matrix.java == '25'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jacoco-report
+          path: '*/target/site/jacoco/'
+          # Warn rather than ignore. Until the modules have tests there is no execution data and
+          # so no report, and a silent green upload of nothing would hide that - as well as hiding
+          # a real break later.
+          if-no-files-found: warn
+          retention-days: 14

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,11 +72,11 @@ was edited.
 
 ## Technical baseline
 
-- Library modules compile with `--release 21`. The CLI module and the toolchain are JDK 25.
-  CI tests 21, 25 and 26.
+- Every module compiles with `--release 21`, the CLI included (ADR-0003, amended at M0.2). The
+  build toolchain is JDK 25. CI tests 21, 25 and 26 on Linux, macOS and Windows.
 - No preview features in any published API — in particular no Structured Concurrency and no Lazy
   Constants.
-- Maven with the wrapper (`./mvnw`). Every module has a `module-info.java`.
+- Maven with the wrapper (`./mvnw`). Every production module has a `module-info.java`.
 - OpenAPI scope: 2.0, 3.0.x, 3.1.x. Not 3.2, not 4.0.
 - Stack: swagger-parser (behind our own interface), networknt json-schema-validator, picocli,
   OkHttp, virtual threads, ANTLR4, Choco, SQLite, JUnit 6, AssertJ, Testcontainers, WireMock,
@@ -97,6 +97,10 @@ restest-cli       command line. The only module allowed to terminate the process
 ```
 
 Dependencies point inwards, towards `restest-core`. Architecture tests enforce this.
+
+A tenth module, `restest-arch-tests`, holds those tests. It has no `src/main`, depends on all nine
+at test scope and is never published — ArchUnit reads bytecode, so the rules can only run somewhere
+that sees every module at once. See ADR-0004, Amendment (M0.2), and `docs/ci.md`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # RESTest 2.0
 
+[![CI](https://github.com/isa-group/RESTest/actions/workflows/ci.yml/badge.svg?branch=v2)](https://github.com/isa-group/RESTest/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+
 > **This branch (`v2`) is a complete rewrite.** It is not backwards-compatible with RESTest 1.x.
 > The 1.x code and documentation remain on `master`.
 
@@ -25,3 +28,7 @@ cd RESTest
 git switch v2
 ./mvnw verify
 ```
+
+That builds all ten modules, runs the test suite and checks the architecture rules. Every push and
+pull request runs the same command on Linux, macOS and Windows against Java 21, 25 and 26 — see
+[docs/ci.md](docs/ci.md).

--- a/docs/PROPOSAL.md
+++ b/docs/PROPOSAL.md
@@ -484,16 +484,21 @@ code moved wholesale.
 | 9 | Fundamental design principles | **Agreed, plus mechanical enforcement** | Architecture tests, mutation testing |
 | 10 | Code and documentation in English | **Agreed** | Including commits, issues and design records |
 
-### 7.1 Java version — build on JDK 25, compile the library for Java 21
+### 7.1 Java version — build on JDK 25, compile everything for Java 21
 
 Latest JDK is 26; latest long-term-support release is 25. Everything this tool needs — records, sealed
 interfaces, pattern matching, virtual threads — is final in 21. Targeting 25 buys nothing semantically
 and excludes the large installed base still on 21, which matters precisely because requirement #5 asks
 for a consumable dependency.
 
-**Library modules target Java 21; the command-line module runs on 25; the build toolchain is 25; CI
-tests 21, 25 and 26.** Avoid Structured Concurrency and Lazy Constants in any published interface —
-both are still preview features and their APIs have changed between releases.
+**Every module targets Java 21, the command-line module included; the build toolchain is 25; CI
+tests 21, 25 and 26.** The CLI was originally to target 25. ADR-0003 was amended at M0.2: a JDK 21
+CI row cannot compile a module targeting 25, and each way around that hid something — either one
+matrix row building a different subset, or a toolchain that `surefire` would honour too, quietly
+running every row's tests on 25.
+
+Avoid Structured Concurrency and Lazy Constants in any published interface — both are still preview
+features and their APIs have changed between releases.
 
 ### 7.2 OAS versions — 2.0, 3.0.x and 3.1.x, fully
 
@@ -942,7 +947,7 @@ Settled with the maintainer, 11 September 2026. These become design records 001�
 |---|---|
 | D1 | **Repository:** long-lived `v2` branch in `isa-group/RESTest`; one short-lived branch per increment; `main` untouched until the end |
 | D2 | **Licence: Apache-2.0** for v2 and for the relicensed IDL assets; add the missing licence file to IDLReasoner-choco; carry over no 1.x source. *Administrative lead time — start now, it blocks M5* |
-| D3 | **Java:** library modules target 21; command-line module and toolchain on 25; CI matrix 21/25/26; no preview features in published interfaces |
+| D3 | **Java:** every module targets 21, CLI included (ADR-0003 amended at M0.2); build toolchain on 25; CI matrix 21/25/26; no preview features in published interfaces |
 | D4 | **IDL parser:** port the grammar to ANTLR4 with a differential conformance test; the `.xtext` grammar remains normative; reuse the IDL-to-CSP mapping as-is |
 | D5 | **Priority:** benchmark metrics first; no external deadline drives the schedule |
 | D6 | **OAS scope:** 2.0, 3.0.x and 3.1.x, fully. 3.2 and 4.0 are out of scope |
@@ -962,7 +967,7 @@ earns its place (decide at the end of M4).
 | Component | Choice | Version (11 Sep 2026) |
 |---|---|---|
 | Library bytecode | Java 21 | — |
-| Command-line module and toolchain | JDK 25 (long-term support) | 25 |
+| Build toolchain | JDK 25 (long-term support) | 25 |
 | Build | Maven with wrapper | 3.9.16 |
 | OAS parser | `io.swagger.parser.v3:swagger-parser`, behind our own interface | 2.1.47 |
 | JSON Schema validation | `com.networknt:json-schema-validator` | 3.0.7 |

--- a/docs/adr/0003-java-baseline.md
+++ b/docs/adr/0003-java-baseline.md
@@ -1,7 +1,11 @@
-# ADR-0003: Library modules target Java 21; the CLI and the toolchain use JDK 25
+# ADR-0003: Every module targets Java 21; the build toolchain uses JDK 25
 
-**Status:** Accepted
-**Date:** 2026-09-11
+**Status:** Accepted, amended at M0.2
+**Date:** 2026-09-11 (amended 2026-09-11)
+
+> The Decision and Consequences below are as originally accepted, with the two superseded points
+> marked. The amendment at the end of this document is the current state: the CLI targets Java 21
+> like every other module. Nothing else changed.
 
 ## Context
 
@@ -22,7 +26,8 @@ rounds. Stable Values was previewed in 25 and renamed to Lazy Constants with a d
 ## Decision
 
 - Library modules compile with `maven.compiler.release=21`.
-- The CLI module and the build toolchain use JDK 25.
+- ~~The CLI module and the build toolchain use JDK 25.~~ **Superseded at M0.2:** the build toolchain
+  uses JDK 25, but the CLI compiles with `release=21` like every other module. See the amendment.
 - CI runs the test suite on 21, 25 and 26, across Linux, macOS and Windows.
 - No preview feature appears in any published API. Concurrency uses plain virtual threads and
   `Executors.newVirtualThreadPerTaskExecutor()`.
@@ -33,7 +38,9 @@ rounds. Stable Values was previewed in 25 and renamed to Lazy Constants with a d
 - The 21 column of the CI matrix is what makes that promise real rather than aspirational.
 - We forgo Scoped Values in the library (final in 25). Where per-request context is needed, it is
   passed explicitly — which is better design anyway.
-- Two compilation targets in one build. Handled by the Maven toolchain; a small, one-off cost.
+- ~~Two compilation targets in one build. Handled by the Maven toolchain; a small, one-off cost.~~
+  **Superseded at M0.2:** there is one compilation target, and therefore no toolchain configuration
+  in the build at all. See the amendment.
 
 ## Alternatives considered
 
@@ -42,3 +49,53 @@ rounds. Stable Values was previewed in 25 and renamed to Lazy Constants with a d
 - **JDK 26 or newer.** Would give HTTP/3 in the JDK's own HTTP client. Rejected: not an LTS,
   supported for six months, and almost nobody could depend on the library.
 - **Java 17.** Rejected: virtual threads are the mechanism behind the entire concurrency design.
+
+## Amendment (M0.2)
+
+**Date:** 2026-09-11
+
+The command-line module now compiles with `--release 21` like every other module. The build
+toolchain and the CI matrix are unchanged.
+
+### Why
+
+The decision above set the CLI to `--release 25`, which makes the JDK 21 row of the CI matrix
+unable to compile the reactor: `javac` on 21 cannot target 25. Two ways out were considered.
+
+Excluding `restest-cli` from the 21 row (`-pl '!restest-cli'`) works, needs nothing installed, and
+states a true fact — the CLI is not consumable on 21 by design. It also means one row of the matrix
+builds something different from the other eight, which is a footnote every future reader has to
+carry.
+
+Registering a JDK 25 toolchain so that every row compiles the CLI is the literal reading of "the
+build toolchain uses JDK 25". It has a trap: `maven-surefire-plugin` honours the session toolchain
+too, so without an explicit `<jvm>` override the tests would run on JDK 25 on every row and the
+matrix would silently stop testing 21 and 26 at runtime. A gate that looks like it tests three
+Java versions while testing one is worse than no gate.
+
+`--release 21` everywhere avoids both. Every row builds and tests the whole reactor, the build
+needs no toolchain configuration, and nothing in the CLI requires a 25-only language feature —
+picocli does not, and this ADR already forbids preview features in published APIs.
+
+### What it costs
+
+The CLI forgoes Scoped Values, final in 25, and the JDK 25 AOT startup cache. Neither is in use.
+Startup time is answered properly by the GraalVM native binary at M7.3, not by a bytecode target.
+
+### What is unchanged
+
+- Library bytecode is Java 21, which is the promise this ADR exists to make.
+- The build toolchain is JDK 25. `--release` and the JDK running the build are independent.
+- CI runs the test suite on 21, 25 and 26 across Linux, macOS and Windows.
+- No preview features in any published API.
+
+`PublishedBytecodeTest` in `restest-arch-tests` checks this claim by reading the class file headers
+the build actually produced. It excludes `module-info.class`, which `javac` emits at the compiling
+JDK's class file version regardless of `--release`; a JDK 21 runtime resolves and runs such a module
+regardless, which was verified rather than assumed.
+
+Being exact about its present state: at M0.2 the modules contain nothing *but* module descriptors,
+so the scan has nothing to examine and skips, with the reason recorded against the skipped test. It
+begins asserting on every build at M1.1, with the first class. What is checked today is the
+instrument rather than the claim — a companion test calibrates the header reader against bytes whose
+version is known.

--- a/docs/adr/0004-module-structure.md
+++ b/docs/adr/0004-module-structure.md
@@ -56,3 +56,35 @@ nothing in `src/` references a benchmark platform.
   conventions too.
 - **Three modules (core / engine / cli).** Not enough separation to express "no AI in the core" or
   "only one module may see the parser" as compiled facts.
+
+## Amendment (M0.2)
+
+**Date:** 2026-09-11
+
+The repository holds **nine production modules**, exactly as decided above, plus **one verification
+module**, `restest-arch-tests`, which is not published.
+
+### Why
+
+This ADR ends by listing the rules ArchUnit must enforce. Writing them exposed a mechanical problem:
+ArchUnit reads bytecode, so a rule such as "`io.swagger` appears only in `restest-spec`" can only
+run somewhere whose classpath holds every module's classes at once. Inside `restest-core` that rule
+would see one module and pass whether it is correct or broken — the vacuous green build this ADR
+exists to prevent.
+
+`restest-arch-tests` has no `src/main`. It depends on all nine modules at test scope, and nothing
+depends on it, so it is a leaf of the dependency graph and cannot distort the architecture it
+polices. `maven.deploy.skip` keeps it off Maven Central.
+
+The alternative was `restest-cli/src/test/java`, whose classpath already sees the other eight. It
+needed no new module and no amendment, but it would put project-wide rules inside the command-line
+module, where nobody looks for them, and `./mvnw verify -pl restest-core` would run no architecture
+checks at all while appearing to pass.
+
+### Consequences
+
+- The nine-module production structure, and the rule that dependencies point inwards, are unchanged.
+- `restest-arch-tests` is exempt from "each module has a `module-info.java`" because it has no main
+  sources. The exemption is named in `SourceTreeRulesTest` rather than implied.
+- The module produces an empty jar, and Maven says so on every build. Suppressing it with
+  `skipIfEmpty` would leave `mvn install` without an artifact to install, so the warning stays.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,8 +40,8 @@ licence. Do not write one for ordinary implementation choices — those belong i
 |---|---|---|
 | [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
 | [0002](0002-rewrite-not-refactor.md) | Rewrite rather than refactor; Apache-2.0; no 1.x source | Accepted |
-| [0003](0003-java-baseline.md) | Library targets Java 21; CLI and toolchain on 25 | Accepted |
-| [0004](0004-module-structure.md) | Multi-module structure and inward dependencies | Accepted |
+| [0003](0003-java-baseline.md) | Every module targets Java 21; toolchain on 25 | Accepted, amended at M0.2 |
+| [0004](0004-module-structure.md) | Multi-module structure and inward dependencies | Accepted, amended at M0.2 |
 | [0005](0005-interpreted-test-model.md) | Test cases are data, not generated source code | Accepted |
 | [0006](0006-event-stream-and-store.md) | One event stream; every interaction persisted | Accepted |
 | [0007](0007-specification-parser-boundary.md) | The parser sits behind our own interface; OAS 2.0/3.0/3.1 | Accepted |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,185 @@
+# Continuous integration
+
+What runs, how to reproduce it locally, and how to add a rule. The decisions behind it are in
+ADR-0003 (Java versions) and ADR-0004 (module boundaries).
+
+Triggers are pull requests against `master` or `v2`, pushes to those two branches, and manual
+dispatch. A push to a `feat/*` branch with no open pull request runs nothing, which is deliberate: a
+branch under active development would otherwise spend nine runners per commit.
+
+## The matrix
+
+`.github/workflows/ci.yml` builds nine rows: `ubuntu-latest`, `macos-latest` and `windows-latest`
+× Java 21, 25 and 26. Every row runs the same command over the whole reactor:
+
+```bash
+./mvnw --batch-mode --no-transfer-progress verify
+```
+
+Three operating systems because path handling, line endings and file locking differ, and RESTest
+reads and writes files on all of them. Three Java versions because 21 is the bytecode target we
+promise library consumers, 25 is the long-term-support release the build toolchain uses, and 26 is
+the current release — the one that tells us about a breakage before a user hits it.
+
+`fail-fast` is off: one red row must not hide the state of the other eight.
+
+The workflow sets `shell: bash` for every step. Windows runners default to PowerShell, which cannot
+execute `mvnw` at all — it is a POSIX shell script with no extension, so `CreateProcess` rejects it.
+Git Bash is on every runner image, so one default makes the same command work everywhere.
+`.gitattributes` keeps `mvnw` checked out with LF endings, because a CRLF copy fails later and less
+legibly, with `bad interpreter: /bin/sh^M`.
+
+Every module targets Java 21, the CLI included, so every row builds and tests everything. There is
+no toolchain configuration and no row that builds a different subset from the others. ADR-0003's
+amendment explains why that beats the alternatives.
+
+## Gates
+
+| Gate | Where it lives | What it fails on |
+|---|---|---|
+| Compilation and unit tests | every module | the obvious |
+| Java 21 bytecode | `PublishedBytecodeTest` | a class file compiled for a later release |
+| Module boundaries | `ProductionArchitectureTest` | a dependency pointing outwards; a class in no module; `io.swagger` outside `restest-spec`; process termination outside `restest-cli` (`System.exit`, `Runtime.exit`/`halt`, this JVM's `ProcessHandle.destroy`, whether called or referenced); a reassignable static field; a network dependency in `restest-core` |
+| The rules themselves | `ArchitectureRulesSelfTest` | a rule that no longer reports the violation it exists to report, or that reports something it should permit |
+| The harness's reach | `HarnessCoverageTest` | a module whose compiled classes the rules cannot see, so no rule constrains them |
+| Source-tree invariants | `SourceTreeRulesTest` | a module without `module-info.java`; a benchmark-platform reference under `src/` or in a POM; an action pinned to a tag, a SHA with no version comment, or no pins found at all |
+| Coverage | JaCoCo | nothing yet — see below |
+
+### Coverage
+
+JaCoCo's agent is attached to every module's test run, and `report` runs at `verify`. A module only
+produces `target/site/jacoco/` once it has tests: with no tests there is no execution data, so the
+report goal skips and says so. At M0.2 that means only `restest-arch-tests` runs any tests, and it
+has no main classes to attribute them to — so **no coverage report is produced yet at all**. The
+wiring is in place; the output arrives with the first tested production code at M1.1.
+
+The ubuntu / 25 row uploads whatever exists as the `jacoco-report` artifact, with
+`if-no-files-found: warn`. Warn rather than ignore on purpose: a silent green upload of nothing
+would hide both today's emptiness and a real break later.
+
+There is deliberately **no** blocking threshold yet. At M0.2 no module contains production code, so
+any minimum would be an assertion about zero classes. The `check` goal arrives in M1.6 on
+`restest-core` and `restest-oracles`, the two modules `docs/PROPOSAL.md` §8.3 names. The commitment
+is recorded as `TODO(M1.6)` beside the JaCoCo block in the root POM.
+
+### Why the rules are tested
+
+The production modules hold nothing but `module-info.java` until M1.1, so there is nothing for the
+rules to match. A rule with no subjects passes whether it is correct or broken, which is the failure
+mode ADR-0004 was written to prevent, so three things guard against it.
+
+First, no check reports a pass over an empty set. `ProductionArchitectureTest`, the bytecode scan
+and the harness-coverage comparison each **skip, with the reason recorded against the skipped
+test** in the surefire XML — not merely in a source comment, so it survives into any report that
+reads the build. Today `./mvnw verify` says:
+
+```
+[WARNING] Tests run: 17, Failures: 0, Errors: 0, Skipped: 7
+```
+
+Seven skips, and the emptiness is on the face of the build rather than hidden behind it. Each skip
+carries a `TODO(M1.1)` and removes itself the moment the first production class exists.
+
+The skip is inside each test rather than in `@BeforeAll` — deliberately, and the difference is not
+cosmetic. An assumption that fails during setup aborts the container, and surefire then records
+`tests="0" skipped="0"` with the reason nowhere in the XML: five architecture checks would simply
+cease to appear in any report, unexplained. Per-test skipping keeps all five visible and attaches
+the reason to each.
+
+Second, `ArchitectureRulesSelfTest` proves the rules independently of whether production code
+exists. Every rule is pointed at `io.restest.arch.fixtures.mirror`, a miniature of the nine-module
+layout whose classes break the rules on purpose, and asserted to fail *and name the offender*. Where
+a rule permits something — `restest-cli` may call `System.exit`, and reaping a child process is not
+terminating our own — that is asserted too, so each rule stays a boundary rather than becoming a
+blanket ban.
+
+Third, `HarnessCoverageTest` checks that the rules can see what they claim to govern. They read the
+module jars off the test classpath, and nothing else verified that list was complete: trim classes
+out of a jar and that module leaves every rule silently and permanently, with the build still green.
+The test compares how many classes each module compiled into `target/classes` against how many the
+rules actually imported. Counts, not presence — "at least one class arrived" would pass a module
+that compiled five hundred and shipped one.
+
+`allowEmptyShould(true)` remains on the individual production checks, for a reason that outlasts
+M0.2: the modules fill in across different milestones, so a rule scoped to one of them legitimately
+has an empty subject set for a while. What it must not excuse is every rule being empty at once, and
+the skips above are what rule that out.
+
+## Reproducing a row locally
+
+Any row, given that JDK:
+
+```bash
+JAVA_HOME=/path/to/jdk-21 ./mvnw --batch-mode verify
+```
+
+On macOS, `/usr/libexec/java_home -V` lists what is installed and `/usr/libexec/java_home -v 21`
+prints the path. Just the rules, without rebuilding everything:
+
+```bash
+./mvnw --batch-mode verify -pl restest-arch-tests -am
+```
+
+There is no shortcut worth having here: `restest-arch-tests` depends on all nine modules, so `-am`
+builds the whole reactor anyway. On this project the full build takes a few seconds; just run
+`./mvnw verify`.
+
+Worth knowing where the rules are actually looking. Under `verify` the reactor has reached
+`package`, so what the rules read is each module's **jar**, not its `target/classes` — only
+`mvn test` leaves them reading the directories. It matters from M1.1 on: anything excluded from a
+jar leaves the architecture rules' field of view entirely. `HarnessCoverageTest` exists for that
+reason — it compares what each module compiled on disk against what the rules actually imported,
+and fails naming any module whose classes the rules cannot see.
+
+Note the converse, which is the real trap: `./mvnw verify -pl restest-core` runs **no** architecture
+checks at all while appearing to pass. They live in `restest-arch-tests`, and only a full-reactor
+build exercises them.
+
+## Adding a rule
+
+Architecture rules go in `ArchitectureRules`, as a factory taking the root package it reasons about:
+
+```java
+static ArchRule myRule(String root) { ... }
+```
+
+The root parameter is not decoration. Rules that name module packages in their own text can only be
+exercised against fixtures if the fixtures live under a parallel package tree, so production passes
+`io.restest` and the self-test passes the mirror root.
+
+Then, in the same commit:
+
+1. A check in `ProductionArchitectureTest`.
+2. A fixture under `io.restest.arch.fixtures.mirror` that breaks the rule on purpose.
+3. An assertion in `ArchitectureRulesSelfTest` that the rule reports it. Where the rule permits
+   something — `restest-cli` may call `System.exit` — assert that too, or the rule is a blanket ban
+   rather than a boundary.
+
+Invariants about text rather than bytecode — a file that must exist, a name that must not appear —
+belong in `SourceTreeRulesTest` instead. ArchUnit cannot see a string that never became a class.
+
+Note the scope of the benchmark-platform rule if you extend it: it reads the module source trees and
+the POMs, and deliberately not `.github` or `evaluation/`. Both exclusions are load-bearing —
+ADR-0011 puts the harness in `evaluation/`, and the nightly benchmark workflow at M1.8 will have to
+invoke it by name, so scanning either would fail on sanctioned work.
+
+## Dependency updates
+
+`.github/dependabot.yml` opens weekly pull requests for Maven dependencies and for the workflow
+actions. Maven updates are grouped, because nine modules share one version property per dependency
+and ungrouped pull requests would all have to land together anyway.
+
+Actions are pinned to commit SHAs, not tags. A tag can be repointed at any commit by whoever owns
+the action; a SHA cannot. The version in the trailing comment is what lets Dependabot recognise the
+pin and bump it, and what tells a human reader which release a SHA is.
+
+`SourceTreeRulesTest` enforces all of that: it fails the build if a pin regresses to a tag, if a SHA
+has no trailing version comment, or if no external pin is found at all — the last so the rule cannot
+quietly stop matching. It scans every `.yml` under `.github`, so composite actions in
+`.github/actions` are covered as well as the workflows.
+
+## Known noise
+
+`restest-arch-tests` has no main sources, so Maven prints `JAR will be empty` on every build.
+Silencing it with `skipIfEmpty` would leave `mvn install` without an artifact to install, so the
+warning stays.

--- a/pom.xml
+++ b/pom.xml
@@ -55,14 +55,67 @@
         <module>restest-oracles</module>
         <module>restest-report</module>
         <module>restest-cli</module>
+        <!-- Verification only: not published, depends on all nine. See ADR-0004, Amendment (M0.2). -->
+        <module>restest-arch-tests</module>
     </modules>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <!-- All library modules target Java 21 (ADR-0003). restest-cli overrides to 25. -->
+        <!-- Every module targets Java 21, restest-cli included (ADR-0003, Amendment (M0.2)). -->
         <maven.compiler.release>21</maven.compiler.release>
+
+        <!-- Versions fixed by docs/PROPOSAL.md, Appendix A. -->
+        <junit.version>6.1.3</junit.version>
+        <assertj.version>3.27.7</assertj.version>
+        <archunit.version>1.5.0</archunit.version>
+        <jacoco.version>0.8.15</jacoco.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.tngtech.archunit</groupId>
+                <artifactId>archunit-junit5</artifactId>
+                <version>${archunit.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <!--
+      Inherited by every module so each one is test-ready without repeating itself.
+      Test scope only: a test framework at compile scope becomes part of the published
+      surface, which is one of the 1.x mistakes ADR-0004 sets out to prevent.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <pluginManagement>
@@ -76,6 +129,17 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.5.4</version>
+                    <configuration>
+                        <!--
+                          Tests run on the classpath, not the module path. The module boundaries
+                          are enforced where they matter - main compilation, plus the ArchUnit
+                          rules in restest-arch-tests - and running tests as named modules would
+                          buy nothing but patch-module ceremony. The module-info check in
+                          SourceTreeRulesTest asserts that no module quietly loses its
+                          module-info.java as a result.
+                        -->
+                        <useModulePath>false</useModulePath>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -92,7 +156,46 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.4.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <!--
+                      TODO(M1.6): add a `check` execution enforcing line and branch minima on
+                      restest-core and restest-oracles, the two modules docs/PROPOSAL.md 8.3 names.
+                      Deferred deliberately: at M0.2 no module contains production code, so any
+                      threshold would be an assertion about zero classes.
+
+                      Note what this does and does not do today. The agent is attached and `report`
+                      runs, but a module with no tests produces no execution data, so the report
+                      goal skips - which at M0.2 means no coverage report is produced at all. The
+                      wiring is here so that M1.1 gets measurement for free; the output arrives with
+                      the first tested code. See docs/ci.md.
+                    -->
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/restest-arch-tests/pom.xml
+++ b/restest-arch-tests/pom.xml
@@ -11,56 +11,85 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>restest-cli</artifactId>
-    <name>RESTest :: CLI</name>
-    <description>Command line. The only module permitted to terminate the process.</description>
+    <artifactId>restest-arch-tests</artifactId>
+    <name>RESTest :: Architecture tests</name>
+    <description>
+        Verification only. Holds the ArchUnit rules that enforce ADR-0004, and the source-tree
+        rules that enforce invariants no bytecode can express. See ADR-0004, Amendment (M0.2).
 
-    <!--
-      No maven.compiler.release override here. The CLI targets Java 21 like every other
-      module, so a single reactor build works on any JDK from 21 upwards, and no toolchain
-      configuration is needed. See ADR-0003, Amendment (M0.2).
-    -->
+        This module has no src/main. It depends on all nine production modules because ArchUnit
+        reads bytecode: a rule such as "io.swagger appears only in restest-spec" can only run
+        somewhere whose classpath holds every module's classes at once. Nothing depends on this
+        module in turn, so it is a leaf of the dependency graph and cannot distort the
+        architecture it polices.
+    </description>
+
+    <properties>
+        <!-- Verification scaffolding, never published. -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- All nine production modules, so their classes are on the test classpath. -->
         <dependency>
             <groupId>io.restest</groupId>
             <artifactId>restest-core</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.restest</groupId>
             <artifactId>restest-spec</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.restest</groupId>
             <artifactId>restest-idl</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.restest</groupId>
             <artifactId>restest-gen</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.restest</groupId>
             <artifactId>restest-exec</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.restest</groupId>
             <artifactId>restest-store</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.restest</groupId>
             <artifactId>restest-oracles</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.restest</groupId>
             <artifactId>restest-report</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.restest</groupId>
+            <artifactId>restest-cli</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRules.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRules.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch;
+
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAnyPackage;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaAccess;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import com.tngtech.archunit.library.Architectures;
+import com.tngtech.archunit.library.Architectures.LayeredArchitecture;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * The architecture rules that ADR-0004 and the design principles in {@code CLAUDE.md} describe in
+ * prose. This class holds the rules; {@link ProductionArchitectureTest} applies them to the real
+ * modules and {@link ArchitectureRulesSelfTest} applies them to deliberate violations, proving each
+ * rule actually reports what it claims to.
+ *
+ * <p>Every rule is a factory taking the root package it should reason about. Rules such as "only
+ * {@code restest-spec} may see the parser" name module packages in their own text, so they can only
+ * be exercised against fixtures if the fixtures live under a parallel package tree. The root
+ * parameter is what makes that possible: production passes {@code io.restest}, the self-test passes
+ * the mirror package under {@code io.restest.arch.fixtures}.
+ */
+final class ArchitectureRules {
+
+    private ArchitectureRules() {
+    }
+
+    /**
+     * ADR-0004: "Dependencies point inwards, towards restest-core." Expressed as the exact graph the
+     * module POMs declare, so a POM that grows an outward dependency fails here rather than being
+     * noticed years later.
+     *
+     * <p>{@code withOptionalLayers} is required because the layers are empty until M1.1 introduces
+     * the domain model. It permits a layer to have no classes; it does not permit a layer to be
+     * accessed by someone who may not access it.
+     *
+     * <p>{@code ensureAllClassesAreContainedInArchitecture} closes the gap that pairing would
+     * otherwise open. {@code consideringOnlyDependenciesInLayers} ignores dependencies of any class
+     * that matches no layer, so a package outside the nine - {@code io.restest.model}, or
+     * {@code io.restest.oracle} written in the singular - would have every one of its dependencies
+     * unchecked while the build stayed green. Requiring every class to belong to a layer turns that
+     * silent gap into a failure that names the package.
+     *
+     * <p>A consequence worth knowing before meeting it: this also rejects a class placed directly in
+     * {@code io.restest}, a root {@code package-info} included, because that package is not one of
+     * the nine modules. That is the intended reading of ADR-0004 - every class belongs to a module -
+     * and not an oversight. If a genuine root-level class is ever wanted, add it through
+     * {@code ensureAllClassesAreContainedInArchitectureIgnoring} deliberately rather than widening
+     * a layer to accommodate it.
+     */
+    static ArchRule dependenciesPointInwards(String root) {
+        LayeredArchitecture architecture = Architectures.layeredArchitecture()
+                .consideringOnlyDependenciesInLayers()
+                .layer("Core").definedBy(root + ".core..")
+                .layer("Spec").definedBy(root + ".spec..")
+                .layer("Idl").definedBy(root + ".idl..")
+                .layer("Gen").definedBy(root + ".gen..")
+                .layer("Exec").definedBy(root + ".exec..")
+                .layer("Store").definedBy(root + ".store..")
+                .layer("Oracles").definedBy(root + ".oracles..")
+                .layer("Report").definedBy(root + ".report..")
+                .layer("Cli").definedBy(root + ".cli..")
+
+                .whereLayer("Cli").mayNotBeAccessedByAnyLayer()
+                .whereLayer("Spec").mayOnlyBeAccessedByLayers("Cli")
+                .whereLayer("Idl").mayOnlyBeAccessedByLayers("Gen", "Cli")
+                .whereLayer("Gen").mayOnlyBeAccessedByLayers("Cli")
+                .whereLayer("Exec").mayOnlyBeAccessedByLayers("Cli")
+                .whereLayer("Store").mayOnlyBeAccessedByLayers("Cli")
+                .whereLayer("Oracles").mayOnlyBeAccessedByLayers("Cli")
+                .whereLayer("Report").mayOnlyBeAccessedByLayers("Cli")
+                .whereLayer("Core").mayOnlyBeAccessedByLayers(
+                        "Spec", "Idl", "Gen", "Exec", "Store", "Oracles", "Report", "Cli");
+
+        return architecture
+                .withOptionalLayers(true)
+                .ensureAllClassesAreContainedInArchitecture()
+                .as("dependencies point inwards, towards " + root + ".core (ADR-0004)");
+    }
+
+    /**
+     * ADR-0007: the third-party specification parser is confined to one module, so replacing it is a
+     * module-sized change. The forbidden package is a parameter so the self-test can point the same
+     * rule at something it can actually depend on without dragging swagger-parser into this module.
+     */
+    static ArchRule onlyOneModuleDependsOn(String root, String module, String forbiddenPackage) {
+        return noClasses()
+                .that().resideOutsideOfPackage(root + "." + module + "..")
+                .and().resideInAPackage(root + "..")
+                .should().dependOnClassesThat().resideInAPackage(forbiddenPackage)
+                .as("only " + root + "." + module + " depends on " + forbiddenPackage
+                        + " (ADR-0007)");
+    }
+
+    /**
+     * ADR-0004 and design principle 9: RESTest is usable as a library, so nothing but the
+     * command-line module may end the JVM. A library that ends the process takes its host down
+     * with it.
+     */
+    static ArchRule onlyOneModuleMayTerminateTheProcess(String root, String module) {
+        return noClasses()
+                .that().resideOutsideOfPackage(root + "." + module + "..")
+                .and().resideInAPackage(root + "..")
+                .should(TERMINATE_THE_PROCESS)
+                .as("only " + root + "." + module + " terminates the process (ADR-0004)");
+    }
+
+    /**
+     * Reaching a process-terminating method, whether by calling it or by referencing it.
+     *
+     * <p>Written as a condition rather than with {@code should().callMethod(...)} because ArchUnit
+     * models a call and a method reference as different things, and {@code callMethod} sees only the
+     * first. {@code System::exit} passed as an {@code IntConsumer} - a fatal-error handler, a
+     * shutdown hook - ends the JVM exactly as thoroughly as {@code System.exit(1)} does, so both
+     * shapes have to be covered or the rule guards only the obvious half. Each is exercised by its
+     * own fixture in {@code ArchitectureRulesSelfTest}.
+     *
+     * <p>Not exhaustive, and knowingly so. {@code System.exit}, {@code Runtime.exit},
+     * {@code Runtime.halt} and {@code ProcessHandle.destroy[Forcibly]} are covered - the last
+     * because it is the modern way to reach for the same effect. Reaching any of them through
+     * reflection or a {@code MethodHandle} is beyond what any bytecode rule can see, and is left to
+     * code review rather than pretended away here.
+     *
+     * <p>The {@code ProcessHandle} clause is narrowed, for a reason that would otherwise surface as
+     * a false positive in someone else's pull request. {@code processHandle.destroy()} reads
+     * identically in bytecode whether the handle is this JVM's or a child process's: both are an
+     * {@code invokeinterface} on {@code java.lang.ProcessHandle}. Killing a child is legitimate and
+     * necessary - the out-of-process transport at M6.2 has to reap its helper - so flagging every
+     * {@code destroy} would fail correct code, and a rule that fails correct code gets switched off.
+     * The clause therefore fires only where the same class also calls {@code ProcessHandle.current()},
+     * which is the only way to obtain a handle on this JVM. Both shapes have fixtures: one that
+     * takes its own handle and destroys it, one that reaps a child.
+     */
+    private static final ArchCondition<JavaClass> TERMINATE_THE_PROCESS =
+            new ArchCondition<>("terminate the process") {
+                @Override
+                public void check(JavaClass item, ConditionEvents events) {
+                    List<JavaAccess<?>> accesses = Stream.<JavaAccess<?>>concat(
+                                    item.getMethodCallsFromSelf().stream(),
+                                    item.getMethodReferencesFromSelf().stream())
+                            .toList();
+                    boolean holdsOwnProcessHandle = accesses.stream()
+                            .anyMatch(ArchitectureRules::takesThisProcessHandle);
+
+                    accesses.stream()
+                            .filter(access -> endsTheProcess(access, holdsOwnProcessHandle))
+                            .forEach(access -> events.add(SimpleConditionEvent.satisfied(
+                                    access, access.getDescription())));
+                }
+            };
+
+    private static boolean endsTheProcess(JavaAccess<?> access, boolean holdsOwnProcessHandle) {
+        String owner = access.getTargetOwner().getName();
+        String method = access.getName();
+        boolean onSystem = System.class.getName().equals(owner) && "exit".equals(method);
+        boolean onRuntime = Runtime.class.getName().equals(owner)
+                && ("exit".equals(method) || "halt".equals(method));
+        boolean onProcessHandle = holdsOwnProcessHandle
+                && ProcessHandle.class.getName().equals(owner)
+                && ("destroy".equals(method) || "destroyForcibly".equals(method));
+        return onSystem || onRuntime || onProcessHandle;
+    }
+
+    /** {@code ProcessHandle.current()}: the only way to get a handle on the running JVM. */
+    private static boolean takesThisProcessHandle(JavaAccess<?> access) {
+        return ProcessHandle.class.getName().equals(access.getTargetOwner().getName())
+                && "current".equals(access.getName());
+    }
+
+    /**
+     * Design principle 6: "No global mutable state. Two runs must coexist in one JVM." A static
+     * field that one run can write is a channel through which it can corrupt another.
+     */
+    static ArchRule noStaticMutableState(String root) {
+        return fields()
+                .that().areStatic()
+                .and().areDeclaredInClassesThat().resideInAPackage(root + "..")
+                .should().beFinal()
+                .as("no static mutable state under " + root + " (design principle 6)");
+    }
+
+    /*
+     * TODO(M1.1): extend the rule above to static *final* fields of a mutable type, which it cannot
+     * currently see. `static final List<String> SEEN = new ArrayList<>()` has a final reference and
+     * writable contents, so it passes the rule while remaining exactly the cross-run channel
+     * design principle 6 forbids.
+     *
+     * It is not a one-line addition, which is why M0.2 does not attempt it. The declared type
+     * cannot decide it: `new ArrayList<>()` and `List.of(...)` are both declared `List`, so a rule
+     * reading only `field.getRawType()` either misses the first or falsely reports the second - and
+     * a rule with false positives gets switched off, at which point it guards nothing. Doing it
+     * properly means inspecting each class's static initializer for the constructor it calls,
+     * which belongs with M1.1, where the first real classes and their constants arrive together.
+     */
+
+    /**
+     * ADR-0004: "restest-core: domain model and interfaces. No network, no parser, no heavy
+     * dependencies." The rule states the "no network" half, which is the one a well-meaning change
+     * is most likely to breach.
+     */
+    static ArchRule moduleHoldsNoDependencyOn(String root, String module, String... forbidden) {
+        DescribedPredicate<JavaClass> forbiddenPackages = resideInAnyPackage(forbidden);
+        return noClasses()
+                .that().resideInAPackage(root + "." + module + "..")
+                .should().dependOnClassesThat(forbiddenPackages)
+                .as(root + "." + module + " holds no dependency on " + String.join(", ", forbidden)
+                        + " (ADR-0004)");
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRulesSelfTest.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRulesSelfTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves that the rules in {@link ArchitectureRules} report violations, rather than merely passing.
+ *
+ * <p>This is the test that earns the harness its keep at M0.2. The production modules are empty, so
+ * {@link ProductionArchitectureTest} currently checks nothing - a rule that matches no classes
+ * passes whether it is correct or broken. Here each rule is pointed at
+ * {@code io.restest.arch.fixtures.mirror}, a miniature of the nine-module layout whose classes
+ * break the rules on purpose, and the test asserts the rule fails and names the offender.
+ *
+ * <p>Without these assertions a typo in a package pattern would leave a permanently green build
+ * guarding nothing, which is the exact failure mode ADR-0004 was written to prevent.
+ */
+class ArchitectureRulesSelfTest {
+
+    private static final String MIRROR = "io.restest.arch.fixtures.mirror";
+
+    private static JavaClasses mirrorClasses;
+
+    @BeforeAll
+    static void importMirrorClasses() {
+        mirrorClasses = new ClassFileImporter().importPackages(MIRROR);
+        assertThat(mirrorClasses)
+                .describedAs("the mirror fixtures must be on the test class path, "
+                        + "otherwise every assertion below would be vacuous")
+                .isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("the inward-dependency rule catches a core class reaching out to spec")
+    void dependency_direction_rule_reports_an_outward_dependency() {
+        expectViolation(
+                ArchitectureRules.dependenciesPointInwards(MIRROR),
+                "CoreReachingOutward");
+    }
+
+    @Test
+    @DisplayName("the inward-dependency rule catches a class that belongs to no layer")
+    void dependency_direction_rule_reports_a_class_outside_every_layer() {
+        expectViolation(
+                ArchitectureRules.dependenciesPointInwards(MIRROR),
+                "StrayOutsideEveryLayer");
+    }
+
+    @Test
+    @DisplayName("the confinement rule catches a module other than spec using the parser package")
+    void confinement_rule_reports_a_dependency_from_the_wrong_module() {
+        expectViolation(
+                ArchitectureRules.onlyOneModuleDependsOn(MIRROR, "spec", "java.sql.."),
+                "CoreUsingAForbiddenPackage");
+    }
+
+    @Test
+    @DisplayName("the process-termination rule catches System.exit outside cli, and allows it inside")
+    void termination_rule_reports_an_exit_outside_the_command_line_module() {
+        expectViolation(
+                ArchitectureRules.onlyOneModuleMayTerminateTheProcess(MIRROR, "cli"),
+                "GenTerminatingTheProcess");
+
+        // System::exit compiles to a method reference, which ArchUnit models separately from a
+        // call. A rule using callMethod alone reports the line above and silently passes this one.
+        expectViolation(
+                ArchitectureRules.onlyOneModuleMayTerminateTheProcess(MIRROR, "cli"),
+                "ExecTerminatingByMethodReference");
+
+        // Neither System nor Runtime is named here, yet the JVM goes down just the same.
+        expectViolation(
+                ArchitectureRules.onlyOneModuleMayTerminateTheProcess(MIRROR, "cli"),
+                "ExecTerminatingByProcessHandle");
+
+        // Identical bytecode to the line above, but on a child process, which is legitimate and
+        // which M6.2's out-of-process transport will need. Flagging it would fail correct code.
+        assertThatThrownBy(() -> ArchitectureRules
+                .onlyOneModuleMayTerminateTheProcess(MIRROR, "cli").check(mirrorClasses))
+                .describedAs("reaping a child process must not be reported; only a handle on this "
+                        + "JVM, obtained through ProcessHandle.current(), ends our own process")
+                .hasMessageNotContaining("ExecReapingAChildProcess");
+
+        assertThatThrownBy(() -> ArchitectureRules
+                .onlyOneModuleMayTerminateTheProcess(MIRROR, "cli").check(mirrorClasses))
+                .describedAs("the rule must permit the command-line module its System.exit, "
+                        + "or it is a blanket ban rather than the boundary ADR-0004 describes")
+                .hasMessageNotContaining("CliTerminatingTheProcess");
+    }
+
+    @Test
+    @DisplayName("the static-state rule catches a writable static field")
+    void static_state_rule_reports_a_non_final_static_field() {
+        expectViolation(
+                ArchitectureRules.noStaticMutableState(MIRROR),
+                "requestsSoFar");
+    }
+
+    @Test
+    @DisplayName("the no-network rule catches a forbidden package inside core")
+    void forbidden_dependency_rule_reports_a_banned_package_inside_the_named_module() {
+        expectViolation(
+                ArchitectureRules.moduleHoldsNoDependencyOn(MIRROR, "core", "java.sql.."),
+                "CoreUsingAForbiddenPackage");
+    }
+
+    private static void expectViolation(ArchRule rule, String expectedInMessage) {
+        assertThatThrownBy(() -> rule.check(mirrorClasses))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining(expectedInMessage);
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/HarnessCoverageTest.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/HarnessCoverageTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Checks that the architecture rules can actually see every module they claim to govern.
+ *
+ * <p>{@link ProductionArchitectureTest} imports {@code io.restest} from the class path, which at
+ * test time is the nine jars named as dependencies in this module's POM. Nothing else verifies that
+ * the list is complete. Drop one of those dependencies, mis-scope it, or trim a class out of a jar,
+ * and the import simply comes back smaller: the rules scoped to that module have an empty subject
+ * set and pass, {@code ensureAllClassesAreContainedInArchitecture} cannot report a class that was
+ * never imported, and {@link ArchitectureRulesSelfTest} never touches the production import at all.
+ * The module would leave every architecture rule silently and permanently, with a green build.
+ *
+ * <p>So this test compares the two things the harness knows independently: how many classes each
+ * module compiled into {@code target/classes}, and how many of them the import actually contains.
+ * Counts rather than presence, because "at least one class arrived" would pass a module that
+ * compiled five hundred and shipped one - a jar-plugin exclude, a shading step or a mis-set source
+ * directory drops a subpackage, and that subpackage leaves every rule unnoticed.
+ *
+ * <p>What it catches, verified by breaking each on purpose: a module whose classes never reached its
+ * jar, and a module that was not built. What it does not catch is one of the nine dependencies being
+ * deleted from this module's POM outright - {@code restest-cli} depends on the other eight, so they
+ * arrive transitively and the import stays complete. That is luck rather than design, and it would
+ * stop being true if the CLI's dependencies ever narrowed, which is a further reason to check the
+ * import against the disk rather than trusting the POM.
+ */
+class HarnessCoverageTest {
+
+    @Test
+    @DisplayName("every class the modules compiled is visible to the architecture rules")
+    void every_compiled_class_is_visible_to_the_rules() {
+        Map<String, Long> compiled = compiledClassesPerModule();
+
+        // TODO(M1.1): this assumption stops holding with the first production class. Until then the
+        // comparison has nothing to compare, and passing an empty list against an empty list would
+        // look like evidence that the rules see every module - while this test's body had never run.
+        Assumptions.assumeFalse(compiled.isEmpty(),
+                "No module has compiled any class beyond its module descriptor yet, so there is "
+                        + "nothing to compare. Skipping rather than asserting emptiness against "
+                        + "emptiness.");
+
+        JavaClasses imported = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages(ROOT);
+
+        List<String> shortfalls = new ArrayList<>();
+        compiled.forEach((module, onDisk) -> {
+            long visible = importedClassesUnder(imported, packageOf(module));
+            if (visible < onDisk) {
+                shortfalls.add(module + ": " + onDisk + " compiled, " + visible
+                        + " visible to the rules");
+            }
+        });
+
+        assertThat(shortfalls)
+                .describedAs("Classes these modules compiled are not reachable by the architecture "
+                        + "rules, so no rule can constrain them. The rules read the module jars, so "
+                        + "the usual causes are a jar-plugin exclude, a shading or multi-release "
+                        + "step, or a missing dependency in restest-arch-tests/pom.xml")
+                .isEmpty();
+    }
+
+    private static final String ROOT = "io.restest";
+
+    /**
+     * How many classes each production module compiled, excluding module descriptors and modules
+     * with none. Read from {@code target/classes} - what {@code javac} produced - so that it is
+     * independent of the jars the rules actually import.
+     */
+    private static Map<String, Long> compiledClassesPerModule() {
+        Path root = RepositoryRoot.locate();
+        Map<String, Long> counts = new LinkedHashMap<>();
+        for (String module : RepositoryRoot.declaredModules()) {
+            if (RepositoryRoot.VERIFICATION_ONLY_MODULES.contains(module)) {
+                continue;
+            }
+            Path output = root.resolve(module).resolve("target/classes");
+            if (!Files.isDirectory(output)) {
+                continue;
+            }
+            try (Stream<Path> tree = Files.walk(output)) {
+                long compiled = tree.filter(Files::isRegularFile)
+                        .filter(path -> path.toString().endsWith(".class"))
+                        .filter(path -> !path.getFileName().toString().equals("module-info.class"))
+                        .count();
+                if (compiled > 0) {
+                    counts.put(module, compiled);
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException("Could not walk " + output, e);
+            }
+        }
+        return counts;
+    }
+
+    private static long importedClassesUnder(JavaClasses imported, String modulePackage) {
+        return imported.stream()
+                .filter(javaClass -> javaClass.getPackageName().equals(modulePackage)
+                        || javaClass.getPackageName().startsWith(modulePackage + "."))
+                .count();
+    }
+
+    /**
+     * {@code restest-core} governs {@code io.restest.core}, and so on.
+     *
+     * <p>The mapping does not hold for {@code restest-arch-tests}, whose package is
+     * {@code io.restest.arch}. That module is excluded by name through
+     * {@link RepositoryRoot#VERIFICATION_ONLY_MODULES} rather than left to this method, which would
+     * otherwise look for {@code io.restest.arch.tests} and report a module it has no business
+     * policing.
+     */
+    private static String packageOf(String module) {
+        assertThat(module).startsWith("restest-");
+        String name = module.substring("restest-".length());
+        assertThat(name)
+                .describedAs("a production module is expected to be restest-<name> mapping to "
+                        + "io.restest.<name>. '%s' has more than one word, so the mapping is a "
+                        + "guess - either exempt it through RepositoryRoot."
+                        + "VERIFICATION_ONLY_MODULES or give it an explicit package here", module)
+                .doesNotContain("-");
+        return ROOT + "." + name;
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/ProductionArchitectureTest.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/ProductionArchitectureTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Applies every rule in {@link ArchitectureRules} to the nine production modules.
+ *
+ * <p>Tests are excluded from the import, so the deliberate violations under
+ * {@code io.restest.arch.fixtures} - which compile to {@code target/test-classes} - are invisible
+ * here. {@link ArchitectureRulesSelfTest} is where those are used.
+ *
+ * <p>At M0.2 the production modules contain nothing but {@code module-info.java}, so there is
+ * nothing here to check yet. Rather than let the rules pass over an empty set - a green build that
+ * guards nothing, which is the failure mode ADR-0004 exists to prevent - each check is skipped with
+ * a stated reason. They begin running by themselves at M1.1, when the first classes arrive. What
+ * proves the rules work in the meantime is {@link ArchitectureRulesSelfTest}.
+ *
+ * <p>The skip is per test, not in {@code @BeforeAll}. An assumption that fails during setup aborts
+ * the whole container, and surefire then records {@code tests="0" skipped="0"} with the reason
+ * nowhere in the XML - so five architecture checks would vanish from every report that reads it,
+ * unexplained. Skipping each test individually keeps all five visible as skipped and attaches the
+ * reason to each.
+ */
+class ProductionArchitectureTest {
+
+    private static final String ROOT = "io.restest";
+
+    private static JavaClasses productionClasses;
+
+    @BeforeAll
+    static void importProductionClasses() {
+        productionClasses = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages(ROOT);
+    }
+
+    @Test
+    @DisplayName("dependencies point inwards, towards restest-core (ADR-0004)")
+    void dependencies_point_inwards() {
+        check(ArchitectureRules.dependenciesPointInwards(ROOT));
+    }
+
+    @Test
+    @DisplayName("only restest-spec references the swagger parser (ADR-0007)")
+    void only_restest_spec_references_the_swagger_parser() {
+        check(ArchitectureRules.onlyOneModuleDependsOn(ROOT, "spec", "io.swagger.."));
+    }
+
+    @Test
+    @DisplayName("only restest-cli terminates the process (ADR-0004)")
+    void only_restest_cli_terminates_the_process() {
+        check(ArchitectureRules.onlyOneModuleMayTerminateTheProcess(ROOT, "cli"));
+    }
+
+    @Test
+    @DisplayName("no static mutable state anywhere (design principle 6)")
+    void no_static_mutable_state() {
+        check(ArchitectureRules.noStaticMutableState(ROOT));
+    }
+
+    @Test
+    @DisplayName("restest-core holds no network dependency (ADR-0004)")
+    void core_holds_no_network_dependency() {
+        check(ArchitectureRules.moduleHoldsNoDependencyOn(
+                ROOT, "core", "java.net..", "okhttp3..", "javax.net.."));
+    }
+
+    /**
+     * Runs a rule against the production modules.
+     *
+     * <p>{@code allowEmptyShould} stays on for a reason that outlasts M0.2: the modules fill in
+     * across different milestones, so a rule scoped to one of them - the parser confinement rule
+     * once {@code restest-spec} exists but {@code restest-oracles} does not - legitimately has an
+     * empty subject set for a while. The case it must not excuse is *every* rule being empty at
+     * once, and the assumption immediately below is what rules that out.
+     */
+    private static void check(ArchRule rule) {
+        // TODO(M1.1): this assumption stops holding as soon as the domain model lands, at which
+        // point every check below starts running on its own and this call can be deleted.
+        Assumptions.assumeFalse(productionClasses.isEmpty(),
+                "No production classes under " + ROOT + " yet: every module holds only a "
+                        + "module-info.java until M1.1. Skipping rather than passing over an empty "
+                        + "set, which would prove nothing. The rules themselves are proven by "
+                        + "ArchitectureRulesSelfTest.");
+
+        rule.allowEmptyShould(true).check(productionClasses);
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/PublishedBytecodeTest.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/PublishedBytecodeTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Checks that the bytecode the build actually produces is Java 21, which is the whole of ADR-0003's
+ * promise to library consumers.
+ *
+ * <p>The promise is not abstract. A project on Java 21 cannot load a class compiled for 25 no matter
+ * what that class does, so {@code maven.compiler.release=21} is the single setting standing between
+ * RESTest and a large share of its potential users. A setting is easy to lose in a POM edit; the
+ * class file header is the evidence.
+ *
+ * <p>At M0.2 the production modules hold nothing but {@code module-info.java}, which this test
+ * excludes for the reason given on {@link #MODULE_DESCRIPTOR}. There is therefore nothing yet to
+ * measure, and the scan reports as skipped rather than passing over an empty set. What is proven
+ * today is the mechanism: {@link #reads_the_major_version_from_a_class_file_header()} checks the
+ * header reader against bytes whose version is known, so when the first real class arrives at M1.1
+ * the scan is measuring with an instrument that has been calibrated.
+ */
+class PublishedBytecodeTest {
+
+    /** Class file major version 65 is Java 21. See JVMS 4.1. */
+    private static final int JAVA_21 = 65;
+
+    /**
+     * Excluded deliberately, after checking what javac actually does.
+     *
+     * <p>{@code javac --release 21} emits {@code module-info.class} at the class file version of the
+     * compiling JDK, not of the release target: built on JDK 25 it comes out as major version 69
+     * even though every other class in the same invocation comes out as 65. This is javac's
+     * behaviour, not a misconfiguration, and it is harmless - a JDK 21 runtime resolves such a
+     * module, compiles against it and runs code from it, because the module system reads descriptors
+     * leniently. Asserting 65 here would therefore fail the build over something correct.
+     *
+     * <p>Verified rather than assumed: a module compiled on JDK 25 with {@code --release 21} was run
+     * on JDK 21 as a named module during M0.2.
+     */
+    private static final String MODULE_DESCRIPTOR = "module-info.class";
+
+    @Test
+    @DisplayName("every published class file is Java 21 bytecode (ADR-0003)")
+    void every_published_class_file_is_java_21_bytecode() {
+        List<Path> classFiles = publishedClassFiles();
+
+        // TODO(M1.1): delete this assumption once the domain model gives the scan something to
+        // measure. Until then it reports as skipped, which is the truth; passing over an empty set
+        // would read as evidence that the bytecode is Java 21 when nothing was examined.
+        Assumptions.assumeFalse(classFiles.isEmpty(),
+                "No compiled classes in the production modules yet, only module descriptors, which "
+                        + "this test excludes by design. Nothing to measure until M1.1.");
+
+        Map<String, Integer> wrongVersion = new LinkedHashMap<>();
+        for (Path classFile : classFiles) {
+            int major = majorVersionOf(classFile);
+            if (major != JAVA_21) {
+                wrongVersion.put(RepositoryRoot.locate().relativize(classFile).toString(), major);
+            }
+        }
+
+        assertThat(wrongVersion)
+                .describedAs("A consumer on Java 21 cannot load a class compiled for a later "
+                        + "release, whatever the class does. Class files examined: %d",
+                        classFiles.size())
+                .isEmpty();
+    }
+
+    /**
+     * Calibrates the header reader, so that the scan above is not the only thing standing behind
+     * ADR-0003's claim while the modules are still empty.
+     *
+     * <p>A class file header is the magic number, then the minor version, then the major version -
+     * six bytes, which is little enough to write out and know the answer in advance.
+     */
+    @Test
+    @DisplayName("the header reader returns the major version a class file declares")
+    void reads_the_major_version_from_a_class_file_header() throws IOException {
+        assertThat(majorVersionOf(classFileHeader(JAVA_21))).isEqualTo(JAVA_21);
+        assertThat(majorVersionOf(classFileHeader(69))).isEqualTo(69);
+
+        Path notAClassFile = Files.createTempFile("not-a-class", ".bin");
+        Files.write(notAClassFile, new byte[] {0, 1, 2, 3, 4, 5, 6, 7});
+        assertThatThrownBy(() -> majorVersionOf(notAClassFile))
+                .describedAs("a file that is not a class file must be reported, not read as "
+                        + "whatever its fourth and fifth bytes happen to be")
+                .isInstanceOf(AssertionError.class);
+    }
+
+    /** Six bytes: the class file magic number, minor version 0, then {@code major}. */
+    private static Path classFileHeader(int major) throws IOException {
+        Path file = Files.createTempFile("header-" + major, ".class");
+        ByteBuffer header = ByteBuffer.allocate(8)
+                .putInt(0xCAFEBABE)
+                .putShort((short) 0)
+                .putShort((short) major);
+        Files.write(file, header.array());
+        return file;
+    }
+
+    /** Every compiled class in a production module, excluding module descriptors. */
+    private static List<Path> publishedClassFiles() {
+        Path root = RepositoryRoot.locate();
+        List<Path> classes = new ArrayList<>();
+        for (String module : RepositoryRoot.declaredModules()) {
+            Path output = root.resolve(module).resolve("target/classes");
+            if (!Files.isDirectory(output)) {
+                // A module with no main sources, or a reactor that has not been built yet.
+                continue;
+            }
+            try (Stream<Path> tree = Files.walk(output)) {
+                tree.filter(Files::isRegularFile)
+                        .filter(path -> path.toString().endsWith(".class"))
+                        .filter(path -> !path.getFileName().toString().equals(MODULE_DESCRIPTOR))
+                        .forEach(classes::add);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Could not walk " + output, e);
+            }
+        }
+        return classes;
+    }
+
+    /** The major version from a class file header: magic, then minor, then major. */
+    private static int majorVersionOf(Path classFile) {
+        try (InputStream in = Files.newInputStream(classFile);
+                DataInputStream data = new DataInputStream(in)) {
+            int magic = data.readInt();
+            assertThat(magic)
+                    .describedAs("%s does not start with the class file magic number", classFile)
+                    .isEqualTo(0xCAFEBABE);
+            data.readUnsignedShort();
+            return data.readUnsignedShort();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not read the header of " + classFile, e);
+        }
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/RepositoryRoot.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/RepositoryRoot.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Locates the repository checkout, for the rules that have to read files rather than bytecode.
+ *
+ * <p>Surefire's working directory is the module being tested, so the root is found by walking
+ * upwards until a directory holds both the aggregator {@code pom.xml} and the {@code restest-core}
+ * module. Failure is loud rather than skipped: a rule that quietly does nothing when it cannot find
+ * the tree is worse than no rule at all.
+ */
+final class RepositoryRoot {
+
+    private static final Pattern MODULE = Pattern.compile("<module>\\s*([^<\\s]+)\\s*</module>");
+
+    private static final Pattern XML_COMMENT = Pattern.compile("<!--.*?-->", Pattern.DOTALL);
+
+    private RepositoryRoot() {
+    }
+
+    /**
+     * Modules that exist to verify the others: no {@code src/main}, never published, and therefore
+     * exempt from the rules that are about production code.
+     *
+     * <p>Named here rather than in each test so the exemption is one decision on the record. Note
+     * that {@code restest-arch-tests} also does not fit the {@code restest-<name>} to
+     * {@code io.restest.<name>} mapping - its package is {@code io.restest.arch}, not
+     * {@code io.restest.arch.tests} - which is a second reason not to leave it to be excluded by a
+     * side effect of having no classes.
+     */
+    static final List<String> VERIFICATION_ONLY_MODULES = List.of("restest-arch-tests");
+
+    /** The directory holding the aggregator POM. */
+    static Path locate() {
+        Path candidate = Path.of("").toAbsolutePath();
+        while (candidate != null) {
+            if (Files.isRegularFile(candidate.resolve("pom.xml"))
+                    && Files.isDirectory(candidate.resolve("restest-core"))) {
+                return candidate;
+            }
+            candidate = candidate.getParent();
+        }
+        throw new IllegalStateException(
+                "Could not find the repository root above " + Path.of("").toAbsolutePath()
+                        + ". The source-tree rules need the checkout to read.");
+    }
+
+    /**
+     * The module names the aggregator POM declares, in declaration order.
+     *
+     * <p>Comments are stripped first. A module commented out to bisect a build is not in the
+     * reactor, and treating it as declared makes one rule demand a file from a module that is not
+     * being built while another silently skips it - two wrong answers from one cause.
+     */
+    static List<String> declaredModules() {
+        String pom = XML_COMMENT.matcher(read(locate().resolve("pom.xml"))).replaceAll("");
+        Matcher matcher = MODULE.matcher(pom);
+        List<String> modules = new ArrayList<>();
+        while (matcher.find()) {
+            modules.add(matcher.group(1));
+        }
+        if (modules.isEmpty()) {
+            throw new IllegalStateException("The aggregator POM declares no modules, which cannot "
+                    + "be right - the module regex has probably stopped matching.");
+        }
+        return List.copyOf(modules);
+    }
+
+    static String read(Path file) {
+        try {
+            return Files.readString(file);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not read " + file, e);
+        }
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/SourceTreeRulesTest.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/SourceTreeRulesTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Invariants that live below the level of bytecode, so ArchUnit cannot see them.
+ *
+ * <p>ArchUnit reasons about compiled classes. Three of the project's rules are about text: a name
+ * that must never appear in the source tree, a file every module must declare, and a pin every
+ * workflow step must carry. None of those becomes a class, so each is checked by reading the
+ * repository. {@link RepositoryRoot} finds the checkout.
+ */
+class SourceTreeRulesTest {
+
+    /**
+     * ADR-0011 and the hard rules in CLAUDE.md: the benchmark platform lives in {@code evaluation/},
+     * which is not a Maven module, and the tool must know nothing about it. CLAUDE.md phrases the
+     * rule as a search over {@code src/} that must return zero hits, which is what this test runs.
+     *
+     * <p>Checked as text rather than as a dependency because the danger is not only a compiled
+     * reference. A path, a property name or a comment that assumes the harness's layout couples the
+     * tool to it just as effectively, and no bytecode rule would see any of them. The POM files are
+     * scanned for the same reason: a Maven property pinning the harness's commit would couple the
+     * build to it while leaving every source file clean.
+     *
+     * <p>{@code evaluation/} is excluded, and must be. ADR-0011 puts the harness there, so naming it
+     * inside that directory is the intended state rather than a violation - a rule that failed on
+     * ADR-sanctioned work would be weakened by the first person to hit it.
+     */
+    @Test
+    @DisplayName("no benchmark platform is referenced anywhere under src (ADR-0011)")
+    void no_benchmark_platform_under_src() {
+        List<String> offenders = new ArrayList<>();
+        for (Path file : toolFiles()) {
+            String content = readIfText(file);
+            if (content != null && content.toLowerCase(Locale.ROOT).contains(BENCHMARK_PLATFORM)) {
+                offenders.add(RepositoryRoot.locate().relativize(file).toString());
+            }
+        }
+        assertThat(offenders)
+                .describedAs("ADR-0011 keeps the benchmark platform out of the tool entirely. "
+                        + "These files under src/ mention it; they belong in evaluation/")
+                .isEmpty();
+    }
+
+    /**
+     * ADR-0004: "Nine Maven modules, each with a module-info.java." The declaration is what makes
+     * the boundary compiled rather than conventional, so losing one silently turns a module back
+     * into a package.
+     *
+     * <p>The module list is read from the aggregator POM rather than hard-coded, so a module added
+     * later is covered without anyone remembering to extend this test.
+     */
+    @Test
+    @DisplayName("every production module declares a module-info.java (ADR-0004)")
+    void every_production_module_declares_a_module_info() {
+        Path root = RepositoryRoot.locate();
+        List<String> missing = new ArrayList<>();
+        for (String module : RepositoryRoot.declaredModules()) {
+            if (RepositoryRoot.VERIFICATION_ONLY_MODULES.contains(module)) {
+                continue;
+            }
+            if (!Files.isRegularFile(root.resolve(module).resolve("src/main/java/module-info.java"))) {
+                missing.add(module);
+            }
+        }
+        assertThat(missing)
+                .describedAs("A module without a module-info.java is a package with extra steps. "
+                        + "Modules exempt from this rule, because they have no main sources: %s",
+                        RepositoryRoot.VERIFICATION_ONLY_MODULES)
+                .isEmpty();
+    }
+
+    /**
+     * Supply-chain hygiene, and the reason M0.2 lists it: a tag is a moving pointer. {@code @v5} can
+     * be repointed at any commit by whoever owns the action, so a workflow pinned to a tag runs
+     * whatever that account decides to publish tomorrow. A 40-character commit SHA cannot move.
+     *
+     * <p>Dependabot updates these pins, which is why the version belongs in a trailing comment: it
+     * is what lets Dependabot tell a v5 pin from a v6 one. That comment is checked here too - both
+     * {@code docs/ci.md} and {@code .github/dependabot.yml} call it required, and a requirement
+     * nothing enforces is a preference.
+     *
+     * <p>Composite actions under {@code .github/actions} are scanned as well as the workflows. They
+     * are the usual next step once a workflow repeats itself, and a pin hidden in one would
+     * otherwise escape.
+     */
+    @Test
+    @DisplayName("every workflow action is pinned to a commit SHA")
+    void every_workflow_action_is_pinned_to_a_commit_sha() {
+        List<String> unpinned = new ArrayList<>();
+        List<String> undocumented = new ArrayList<>();
+        int pins = 0;
+
+        for (Path definition : actionDefinitions()) {
+            Matcher matcher = USES.matcher(RepositoryRoot.read(definition));
+            while (matcher.find()) {
+                String reference = matcher.group(1).trim();
+                if (reference.startsWith("./")) {
+                    // A local action in this repository moves with the commit that uses it.
+                    continue;
+                }
+                pins++;
+                if (!PINNED.matcher(reference).matches()) {
+                    unpinned.add(definition.getFileName() + ": " + reference);
+                } else if (!VERSION_COMMENT.matcher(matcher.group(2)).find()) {
+                    undocumented.add(definition.getFileName() + ": " + reference);
+                }
+            }
+        }
+
+        assertThat(unpinned)
+                .describedAs("A tag can be repointed at any commit by whoever owns the action; a "
+                        + "commit SHA cannot. Pin these as owner/repo@<40 hex>")
+                .isEmpty();
+        assertThat(undocumented)
+                .describedAs("A bare SHA tells a reader and Dependabot nothing about which release "
+                        + "it is. Add the version as a trailing comment, as in "
+                        + "'uses: actions/checkout@<sha> # v7.0.1'")
+                .isEmpty();
+        assertThat(pins)
+                .describedAs("No external action pins were found at all, so this rule checked "
+                        + "nothing. Either the workflows stopped using actions, or the pattern "
+                        + "matching 'uses:' has stopped matching")
+                .isPositive();
+    }
+
+    /**
+     * The forbidden name, split so that this file does not match its own rule. The alternative was
+     * to exempt this source file, which would have left a hole in a rule whose whole value is that
+     * it has none.
+     */
+    private static final String BENCHMARK_PLATFORM = "rest" + "gym";
+
+    private static final Pattern USES =
+            Pattern.compile("^[ \\t]*-?[ \\t]*uses:[ \\t]*(\\S+)([^\\n]*)$", Pattern.MULTILINE);
+
+    private static final Pattern PINNED =
+            Pattern.compile("[\\w.-]+/[\\w.-]+(?:/[\\w.-]+)*@[0-9a-f]{40}");
+
+    /** The trailing '# v1.2.3' that tells Dependabot, and a reader, which release the SHA is. */
+    private static final Pattern VERSION_COMMENT = Pattern.compile("#\\s*v?\\d");
+
+    /**
+     * Everything that makes up the tool: the source trees of the declared modules, the repository's
+     * own {@code src/} (which still carries the 1.x test corpus), and every POM.
+     *
+     * <p>Deliberately not a walk of the whole repository. That would descend into {@code .git} and
+     * {@code target}, making the cost scale with history rather than with source, and it would
+     * sweep up {@code evaluation/}, where naming the harness is correct.
+     */
+    private static List<Path> toolFiles() {
+        Path root = RepositoryRoot.locate();
+        List<Path> roots = new ArrayList<>();
+        roots.add(root.resolve("src"));
+        for (String module : RepositoryRoot.declaredModules()) {
+            roots.add(root.resolve(module).resolve("src"));
+        }
+
+        List<Path> files = new ArrayList<>();
+        for (Path sourceTree : roots) {
+            if (!Files.isDirectory(sourceTree)) {
+                continue;
+            }
+            try (Stream<Path> tree = Files.walk(sourceTree)) {
+                tree.filter(Files::isRegularFile).forEach(files::add);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Could not walk " + sourceTree, e);
+            }
+        }
+
+        files.add(root.resolve("pom.xml"));
+        for (String module : RepositoryRoot.declaredModules()) {
+            Path pom = root.resolve(module).resolve("pom.xml");
+            if (Files.isRegularFile(pom)) {
+                files.add(pom);
+            }
+        }
+        return files;
+    }
+
+    /** Every workflow, and every composite action definition under {@code .github}. */
+    private static List<Path> actionDefinitions() {
+        Path github = RepositoryRoot.locate().resolve(".github");
+        assertThat(github.resolve("workflows"))
+                .describedAs("M0.2 introduced the workflow directory; if it is gone, continuous "
+                        + "integration is gone with it")
+                .isDirectory();
+        try (Stream<Path> tree = Files.walk(github)) {
+            return tree.filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".yml")
+                            || path.toString().endsWith(".yaml"))
+                    .toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not walk " + github, e);
+        }
+    }
+
+    /** The file's content, or {@code null} if it is not valid UTF-8 text (the corpus holds images). */
+    private static String readIfText(Path file) {
+        try {
+            byte[] bytes = Files.readAllBytes(file);
+            String decoded = new String(bytes, StandardCharsets.UTF_8);
+            return decoded.indexOf(0) >= 0 ? null : decoded;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not read " + file, e);
+        }
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/cli/CliTerminatingTheProcess.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/cli/CliTerminatingTheProcess.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch.fixtures.mirror.cli;
+
+/**
+ * Breaks no rule. The command-line module is the one place allowed to end the process, so this
+ * class is what stops {@code onlyOneModuleMayTerminateTheProcess} from being a rule that simply
+ * bans {@code System.exit} everywhere.
+ */
+public final class CliTerminatingTheProcess {
+
+    public void exitWithFailure() {
+        System.exit(1);
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/core/CoreReachingOutward.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/core/CoreReachingOutward.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch.fixtures.mirror.core;
+
+import io.restest.arch.fixtures.mirror.spec.SpecType;
+
+/**
+ * Violates {@code dependenciesPointInwards}: the core layer reaches out to the spec layer, which
+ * ADR-0004 says may only be accessed by the command-line module.
+ */
+public final class CoreReachingOutward {
+
+    public String delegate() {
+        return new SpecType().parse();
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/core/CoreUsingAForbiddenPackage.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/core/CoreUsingAForbiddenPackage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch.fixtures.mirror.core;
+
+import java.sql.Date;
+
+/**
+ * Violates {@code onlyOneModuleDependsOn} and {@code moduleHoldsNoDependencyOn}.
+ *
+ * <p>{@code java.sql} stands in for the real forbidden packages - {@code io.swagger} for the parser
+ * rule, {@code java.net} and {@code okhttp3} for the no-network rule. Both rules take the forbidden
+ * package as a parameter precisely so this fixture can use something already on the JDK's class
+ * path: proving the rule fires needs no swagger-parser or OkHttp dependency in this module.
+ */
+public final class CoreUsingAForbiddenPackage {
+
+    public Date today() {
+        return new Date(0L);
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/exec/ExecReapingAChildProcess.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/exec/ExecReapingAChildProcess.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch.fixtures.mirror.exec;
+
+import java.io.IOException;
+
+/**
+ * Breaks no rule, and must stay that way.
+ *
+ * <p>In bytecode this is indistinguishable from {@link ExecTerminatingByProcessHandle}: both are an
+ * {@code invokeinterface} on {@code java.lang.ProcessHandle.destroy}. The difference is whose
+ * process the handle refers to, and killing a child is legitimate - the out-of-process transport at
+ * M6.2 must be able to reap its helper. The rule tells them apart by whether the class also calls
+ * {@code ProcessHandle.current()}, which this one does not.
+ */
+public final class ExecReapingAChildProcess {
+
+    public void runHelper() throws IOException {
+        Process helper = new ProcessBuilder("true").start();
+        helper.toHandle().destroy();
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/exec/ExecTerminatingByMethodReference.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/exec/ExecTerminatingByMethodReference.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch.fixtures.mirror.exec;
+
+import java.util.function.IntConsumer;
+
+/**
+ * Violates {@code onlyOneModuleMayTerminateTheProcess} without ever calling {@code System.exit}.
+ *
+ * <p>{@code System::exit} compiles to a method reference, not a method call, and ArchUnit models the
+ * two separately. A rule written with {@code callMethod} alone reports the direct form and passes
+ * this one, which is the realistic shape of the mistake: a fatal-error handler or a shutdown hook
+ * passed as an {@code IntConsumer}. The JVM goes down either way.
+ */
+public final class ExecTerminatingByMethodReference {
+
+    public IntConsumer fatalErrorHandler() {
+        return System::exit;
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/exec/ExecTerminatingByProcessHandle.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/exec/ExecTerminatingByProcessHandle.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch.fixtures.mirror.exec;
+
+/**
+ * Violates {@code onlyOneModuleMayTerminateTheProcess} without naming {@code System} or
+ * {@code Runtime} at all.
+ *
+ * <p>{@code ProcessHandle.current().destroy()} signals the JVM's own process, which ends it as
+ * thoroughly as {@code System.exit} does. It is also the API a reader is most likely to reach for
+ * today, which is exactly why a rule that enumerated only the two older ones would look complete
+ * and let this through.
+ */
+public final class ExecTerminatingByProcessHandle {
+
+    public void giveUp() {
+        ProcessHandle.current().destroy();
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/gen/GenTerminatingTheProcess.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/gen/GenTerminatingTheProcess.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch.fixtures.mirror.gen;
+
+/**
+ * Violates {@code onlyOneModuleMayTerminateTheProcess}: a library module that ends the JVM takes its
+ * host process down with it.
+ */
+public final class GenTerminatingTheProcess {
+
+    public void giveUp() {
+        System.exit(1);
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/gen/GenWithStaticMutableState.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/gen/GenWithStaticMutableState.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch.fixtures.mirror.gen;
+
+/**
+ * Violates {@code noStaticMutableState}: a static field one run can write is a channel through which
+ * it can corrupt another, which design principle 6 forbids.
+ */
+public final class GenWithStaticMutableState {
+
+    static int requestsSoFar;
+
+    public void count() {
+        requestsSoFar++;
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/package-info.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * A miniature of the nine-module package layout, used only to prove that the rules in
+ * {@code ArchitectureRules} report the violations they claim to.
+ *
+ * <p>Every class below breaks a rule on purpose. Nothing here is production code, nothing depends on
+ * it, and the production checks exclude it by importing with
+ * {@code ImportOption.Predefined.DO_NOT_INCLUDE_TESTS} - these classes compile to
+ * {@code target/test-classes}.
+ *
+ * <p>The mirror exists because the location-based rules name module packages in their own text. A
+ * violation of "only spec may see the parser" has to live in something shaped like a module, so the
+ * rules take a root package and this tree supplies an alternative one.
+ */
+package io.restest.arch.fixtures.mirror;

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/spec/SpecType.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/spec/SpecType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch.fixtures.mirror.spec;
+
+/** Stands in for a type belonging to the specification module. Breaks no rule by itself. */
+public final class SpecType {
+
+    public String parse() {
+        return "parsed";
+    }
+}

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/stray/StrayOutsideEveryLayer.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/stray/StrayOutsideEveryLayer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.arch.fixtures.mirror.stray;
+
+/**
+ * Violates {@code dependenciesPointInwards} by belonging to no layer at all.
+ *
+ * <p>This is the failure mode the layered rule has on its own: with
+ * {@code consideringOnlyDependenciesInLayers}, a class whose package matches none of the nine has
+ * every dependency ignored, so it could reach anywhere it liked and the build would stay green. The
+ * realistic version is not a package called "stray" but a plausible near-miss - a domain model that
+ * lands in {@code io.restest.model}, or an oracle package written in the singular.
+ */
+public final class StrayOutsideEveryLayer {
+
+    public String describe() {
+        return "in no layer";
+    }
+}


### PR DESCRIPTION
**Increment:** 0.2, from `ROADMAP.md`

## What you can do now that you could not before

Break an architectural rule and the build tells you, by name and line number, instead of letting it
through. Write `System.exit` into a library module, leave a `static` field writable, or put a class
in a package that belongs to no module, and `./mvnw verify` fails naming the offender — on Linux,
macOS and Windows, against Java 21, 25 and 26.

Nothing user-facing ships here: there is still no code in the nine production modules. This is the
gate that every later increment lands through, and M1.1 is the first one it will constrain.

## Try it yourself

```bash
git fetch && git switch feat/m0-2-continuous-integration
./mvnw -B verify
```

Real output, tail end:

```
[INFO] Running io.restest.arch.SourceTreeRulesTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] Running io.restest.arch.PublishedBytecodeTest
[WARNING] Tests run: 2, Failures: 0, Errors: 0, Skipped: 1
[INFO] Running io.restest.arch.ProductionArchitectureTest
[WARNING] Tests run: 5, Failures: 0, Errors: 0, Skipped: 5
[WARNING] Running io.restest.arch.HarnessCoverageTest
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1
[INFO] Running io.restest.arch.ArchitectureRulesSelfTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[WARNING] Tests run: 17, Failures: 0, Errors: 0, Skipped: 7
[INFO] BUILD SUCCESS
```

Those seven skips are deliberate, and are the most important thing on that screen — see
**How it works**.

Now make the gate bite. Write a class into `restest-core` that does two forbidden things:

```bash
mkdir -p restest-core/src/main/java/io/restest/core
cat > restest-core/src/main/java/io/restest/core/Rogue.java <<'EOF'
package io.restest.core;

import java.util.function.IntConsumer;

public final class Rogue {

    static int callCount;

    public IntConsumer onFatalError() {
        return System::exit;
    }
}
EOF
printf 'module io.restest.core {\n    exports io.restest.core;\n}\n' > restest-core/src/main/java/module-info.java
./mvnw -B verify
```

Real output:

```
Architecture Violation [Priority: MEDIUM] - Rule 'only io.restest.cli terminates the process
(ADR-0004)' was violated (1 times):
Method <io.restest.core.Rogue.onFatalError()> references method <java.lang.System.exit(int)>
in (Rogue.java:10)

Architecture Violation [Priority: MEDIUM] - Rule 'no static mutable state under io.restest
(design principle 6)' was violated (1 times):
Field <io.restest.core.Rogue.callCount> does not have modifier FINAL in (Rogue.java:0)

[ERROR] Tests run: 17, Failures: 2, Errors: 0, Skipped: 0
```

Note `references method`, not `calls method`. `System::exit` is a method *reference*, which the
usual way of writing this rule does not see at all; see **Decisions taken**.

Then put the same class in a package that belongs to no module and watch a different rule fire:

```bash
rm -rf restest-core/src/main/java/io/restest/core
mkdir -p restest-core/src/main/java/io/restest/model
printf 'package io.restest.model;\npublic final class Probe {}\n' > restest-core/src/main/java/io/restest/model/Probe.java
printf 'module io.restest.core {\n    exports io.restest.model;\n}\n' > restest-core/src/main/java/module-info.java
./mvnw -B verify
```

```
Class <io.restest.model.Probe> is not contained in architecture
```

Undo with:

```bash
rm -rf restest-core/src/main/java/io/restest
printf 'module io.restest.core {\n}\n' > restest-core/src/main/java/module-info.java
```

## How it works

Three things had to be true for this to be a gate rather than a decoration.

**The rules need somewhere to run.** ArchUnit, the library that checks structure, reads *compiled*
code. So a rule like "only `restest-spec` may see the specification parser" can only run somewhere
that can see all nine modules' compiled output at once — inside `restest-core` it would see one
module and pass whether it is right or wrong. Hence a tenth module, `restest-arch-tests`: no source
of its own, depends on all nine, never published. Nothing depends on it in turn, so it cannot bend
the architecture it inspects.

**A rule that checks nothing must not look like a rule that passed.** Every production module is
still empty, so all nine rules currently have nothing to examine. Rather than let them report
success over an empty set — a green build guarding nothing, which is exactly how RESTest 1.x lost
its package conventions — each check is *skipped*, with the reason recorded against it in the
surefire XML, not merely in a comment. That is the `Skipped: 7` above. They switch themselves on
the moment the first real class exists, which is why the same command reports 0 skipped once you
paste in `Rogue.java`.

**And the rules must be able to see every module they claim to govern.** They read the nine module
jars off the test classpath, and nothing else checked that list was complete: trim a class out of a
jar and that module leaves every rule silently, for good, with the build still green.
`HarnessCoverageTest` compares how many classes each module compiled on disk against how many the
rules actually imported — counts, not presence, because "at least one class arrived" would pass a
module that compiled five hundred and shipped one.

**So the rules are tested against code that breaks them.** Under
`io.restest.arch.fixtures.mirror` sits a miniature of the nine-module layout whose classes violate
each rule deliberately: a core class reaching outward, a `System.exit` outside the command line, a
writable static field, a class in no module at all. Each rule is pointed at them and asserted to
fail *and name the offender*. Where a rule permits something — the command-line module may end the
process — that is asserted too, so it stays a boundary rather than becoming a blanket ban. This is
what makes the harness trustworthy today, while it still has no real code to guard.

Alongside that, nine CI rows (three operating systems × three Java versions) run the same single
command, Dependabot opens weekly update pull requests, and every GitHub Action is pinned to an
immutable commit SHA rather than a tag — a tag can be repointed at any commit by whoever owns the
action, and one of the rules fails the build if a pin ever regresses.

## What changed in the code

**New module `restest-arch-tests`** (test sources only, `maven.deploy.skip`):

- `ArchitectureRules` — five rule factories, each parameterised by the root package it reasons
  about. That parameter is what allows the same rule object to be aimed at production *and* at the
  mirror fixtures.
- `ProductionArchitectureTest` — the five rules against `io.restest`, with test classes excluded
  from the import so fixtures cannot contaminate it.
- `ArchitectureRulesSelfTest` — six assertions that each rule reports its violation.
- `HarnessCoverageTest` — asserts the rules can actually see every class the modules compiled.
- `SourceTreeRulesTest` — three invariants that are about *text*, not bytecode, and so cannot be
  ArchUnit rules: every production module declares a `module-info.java`; the benchmark platform is
  named nowhere in the tool (ADR-0011); every action is SHA-pinned with its version in a comment.
- `PublishedBytecodeTest` — reads class file headers and asserts Java 21 bytecode, plus a test that
  calibrates the header reader against synthesised bytes.
- `RepositoryRoot` — locates the checkout and parses the aggregator's module list.

**Build:** root POM gains the versions Appendix A of `docs/PROPOSAL.md` already fixes (JUnit 6.1.3,
AssertJ 3.27.7, ArchUnit 1.5.0, JaCoCo 0.8.15), a `junit-bom` import, test-scoped dependencies
inherited by every module, `useModulePath=false` for surefire, and JaCoCo `prepare-agent` + `report`.
`restest-cli` loses its commented-out `release` 25 override. Maven wrapper 3.9.15 → 3.9.16.

**CI:** `.github/workflows/ci.yml`, `.github/dependabot.yml`, `.gitattributes`.

**Docs:** `docs/ci.md` (new), amendments to ADR-0003 and ADR-0004, and `CLAUDE.md`,
`docs/PROPOSAL.md`, `docs/adr/README.md`, `README.md` brought into line with them.

**Left for later, deliberately:** blocking coverage thresholds → M1.6, marked `TODO(M1.6)` in the
root POM. `-Pit` / `-Psmoke` profiles and Testcontainers/WireMock → M1.7. PIT mutation testing → M3,
when there are oracles to mutate. Per-request overhead regression → M6.4. Nightly benchmark → M1.8.
Extending the static-state rule to `static final` fields of mutable type → M1.1, marked
`TODO(M1.1)`; see **Decisions taken**.

## Evidence

- [x] Tests: 17 added, 10 running and 7 skipped-by-design today, all green — full clean
      `./mvnw verify` on JDK 25 and on JDK 21 locally; CI link on first push
- [x] Architecture tests: 10 added — none weakened; there were none to weaken
- [ ] Mutation score: n/a, no oracles or constraints in this increment
- [ ] Per-request overhead: n/a, no HTTP engine yet (M1.3)
- [ ] Smoke run: n/a, no runnable command yet (M1.7)
- [ ] Idle time: n/a, no run loop yet (M1.3)
- [x] Artefact: the terminal transcripts under **Try it yourself**, all pasted from real runs

## Decisions taken

**1. JaCoCo measures; it does not yet gate.** No module holds production code, so any threshold
would be an assertion about zero classes. `docs/PROPOSAL.md` §8.3 promises thresholds on
`restest-core` and `restest-oracles`; that lands at M1.6, recorded as `TODO(M1.6)` in the root POM.
Being precise about today's state: because the eight library modules have no tests, there is no
execution data, so no coverage report is produced *at all* yet. The wiring is real, the output
arrives with the first tested code. The CI upload uses `if-no-files-found: warn` rather than
`ignore`, so that emptiness is visible now and a future break will be too.

**2. ADR-0003 amended: every module targets Java 21, the CLI included.** M0.1 left the CLI slated
for `--release 25`, which a JDK 21 CI row cannot compile. The two alternatives each concealed
something: excluding `restest-cli` from the 21 row leaves one row building a different subset from
the other eight, and a Maven toolchain is also honoured by `maven-surefire-plugin`, so without an
explicit `<jvm>` override every row's *tests* would run on 25 and the matrix would silently stop
testing 21 and 26. A single target avoids both. Cost: the CLI forgoes Scoped Values and the JDK 25
AOT startup cache, neither in use; startup time is answered by the native binary at M7.3. ADR-0003
is retitled, its two superseded points struck through in place, and `CLAUDE.md`,
`docs/PROPOSAL.md` and `docs/adr/README.md` updated — no document is left contradicting another.

**3. ADR-0004 amended: a tenth, unpublished verification module.** Reasoning under **How it works**.
The alternative, `restest-cli/src/test/java`, needed no amendment but would bury project-wide rules
inside the command-line module and let `./mvnw verify -pl restest-core` run no architecture checks
while appearing to pass.

**4. Skipped, not passed, when there is nothing to check — and skipped per test, not per class.**
`allowEmptyShould(true)` remains on the individual rules, because modules arrive across different
milestones and a rule scoped to one of them is legitimately empty for a while. What it must not
excuse is *every* rule being empty at once, so `ProductionArchitectureTest` and the bytecode scan
skip with a stated reason. Both carry `TODO(M1.1)` and remove themselves when the first class lands.

The skip is inside each test rather than in `@BeforeAll`. I had it in `@BeforeAll` first, which
aborts the container: surefire then records `tests="0" skipped="0"` and the reason appears in no
artefact at all, so five architecture checks would silently vanish from any report reading the XML.
Per-test skipping gives `tests="5" skipped="5"` with the reason attached to each — checked in the
generated XML, not assumed.

**5. The rules are checked against the disk, not trusted from the POM.** `HarnessCoverageTest`
exists because nothing else would notice a module leaving the harness's field of view. It compares
per-module *counts* rather than presence: verified by trimming only
`io/restest/spec/internal/**` out of `restest-spec`'s jar, which a presence check passes and this
one fails with `["restest-spec: 2 compiled, 1 visible to the rules"]`. Two things recorded honestly
in its Javadoc: deleting a dependency outright does *not* trip it, because `restest-cli` pulls the
other eight in transitively — luck rather than design, and a further argument for comparing against
the disk; and it skips rather than passing while no module has compiled anything, so that the guard
the rest of the harness leans on cannot sit green having never run its own body.

**6. The termination rule is a condition, not `callMethod`.** ArchUnit models a method call and a
method reference as different things, and `should().callMethod(...)` sees only the first.
`System::exit` handed over as an `IntConsumer` — a fatal-error handler, a shutdown hook — ends the
JVM just as thoroughly. The rule inspects both, plus `ProcessHandle.destroy` and `destroyForcibly`,
which reach the same end without naming `System` or `Runtime` at all and are what a reader is most
likely to write today.

The `ProcessHandle` clause is narrowed rather than blanket, and that narrowing is the interesting
part. `processHandle.destroy()` is identical in bytecode whether the handle is this JVM's or a child
process's, and killing a child is legitimate — the out-of-process transport at M6.2 has to reap its
helper. So the clause fires only where the same class also calls `ProcessHandle.current()`, the only
way to obtain a handle on the running JVM. Two fixtures hold that line: one that takes its own
handle and destroys it, one that reaps a child and must *not* be reported. Widening the clause back
makes the second fixture fail, which is how I know the narrowing is load-bearing rather than
decorative. Reflection and `MethodHandle` are beyond any bytecode rule; the Javadoc says so rather
than implying the list is exhaustive.

**7. A rule was cut rather than shipped half-working.** I had begun a rule for `static final`
fields of mutable type — `static final List<String> SEEN = new ArrayList<>()` has a final reference
and writable contents, so rule 4 passes it. It cannot be decided from the declared type:
`new ArrayList<>()` and `List.of(...)` are both declared `List`, so the rule would either miss the
first or falsely report the second, and a rule with false positives gets switched off. Doing it
properly means inspecting each class's static initializer, which belongs with M1.1 where the first
real constants arrive. Removed, with the reasoning left as `TODO(M1.1)` in `ArchitectureRules`.

**8. `.gitattributes` is deliberately narrow.** It pins line endings for `mvnw`, `*.sh`, `mvnw.cmd`
and `*.bat` and stops there. A blanket `* text=auto` is what I wrote first, and it would have marked
`src/test/resources/AmadeusTravelRestrictions/data/CountryCodes-ISO-3166-1-alpha-2.csv` — tracked
with CRLF in the index — as unnormalised, so the next `git add -A` near it would have committed a
whole-file line-ending change to a 1.x fixture nobody had opened. The four rules are all the Windows
rows need.

**9. Two items outside the strict scope of 0.2, kept and flagged.** The Maven wrapper bump matches
Appendix A and was exercised by both local verification runs. The inherited test dependencies in the
root POM serve only `restest-arch-tests` today; they are there so M1.1 does not have to edit nine
POMs.

## Open questions

None blocking. One thing worth a maintainer's eye: seven of seventeen tests reporting as skipped is
intentional and self-removing, but it is unusual enough that it may read as a misconfiguration to
someone meeting the repository for the first time. Each skip states its reason in the surefire XML,
and `docs/ci.md` explains the design; if you would rather see a different signal — a failing
placeholder, or the checks simply absent until M1.1 — say so and I will change it.

---

- [x] Targets `v2`, not `main`
- [x] English throughout, including comments and test names
- [x] Nothing from the deferred backlog (`docs/PROPOSAL.md` §11)
- [x] No AI abstraction; no benchmark-platform reference under `src/`
- [x] Reviewed by the `reviewer` subagent
