### PR TITLE
Make Javadoc self-contained and understandable without the project's internal planning docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,16 @@ Work breakdown: `ROADMAP.md`.
 English only — code, comments, tests, commits, branches, issues, pull requests, documentation.
 No exceptions.
 
+## Javadoc comments
+
+- Never reference `ADR-*`, `docs/DESIGN.md`, `docs/adr/`, `ROADMAP.md` or a milestone code
+  (`M1.3`, `M4.2`...) from a Javadoc comment (`/** ... */`). Javadoc must be self-contained; the
+  only references it may carry are `{@link}`s to other code. This does not apply to plain `//` or
+  `/* */` comments, or to string literals such as `@DisplayName` or `.as(...)` rule descriptions.
+- Keep Javadoc simple and avoid unnecessary technical jargon.
+- At least the class-level comment must explain, in plain language a non-programmer could follow,
+  what the class is used for when testing a REST API and how it relates to other classes.
+
 ## Branching and increments
 
 - `master` is untouched until v2.0 is complete. All work targets the long-lived `v2` branch.

--- a/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRules.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRules.java
@@ -33,10 +33,12 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /**
- * The architecture rules that ADR-0004 and the design principles in {@code CLAUDE.md} describe in
- * prose. This class holds the rules; {@link ProductionArchitectureTest} applies them to the real
- * modules and {@link ArchitectureRulesSelfTest} applies them to deliberate violations, proving each
- * rule actually reports what it claims to.
+ * The rules that keep this project's own code organised the way it is meant to be: which parts of
+ * the tool are allowed to depend on which others, and which parts may end the program.
+ *
+ * <p>This class holds the rules themselves; {@link ProductionArchitectureTest} applies them to the
+ * real code and {@link ArchitectureRulesSelfTest} applies them to small examples that deliberately
+ * break each rule, proving that the rule actually reports what it claims to.
  *
  * <p>Every rule is a factory taking the root package it should reason about. Rules such as "only
  * {@code restest-spec} may see the parser" name module packages in their own text, so they can only
@@ -50,27 +52,24 @@ final class ArchitectureRules {
     }
 
     /**
-     * ADR-0004: "Dependencies point inwards, towards restest-core." Expressed as the exact graph the
-     * module POMs declare, so a POM that grows an outward dependency fails here rather than being
-     * noticed years later.
+     * "Dependencies point inwards, towards restest-core" - one of this project's own module rules,
+     * expressed here as the exact graph the module build files declare, so a change that adds a
+     * dependency in the wrong direction fails here rather than being noticed years later.
      *
-     * <p>{@code withOptionalLayers} is required because the layers are empty until M1.1 introduces
-     * the domain model. It permits a layer to have no classes; it does not permit a layer to be
-     * accessed by someone who may not access it.
+     * <p>{@code withOptionalLayers} is required because some of these module packages start out with
+     * no classes in them and fill in over time. It permits a layer to have no classes; it does not
+     * permit a layer to be accessed by someone who may not access it.
      *
-     * <p>{@code ensureAllClassesAreContainedInArchitecture} closes the gap that pairing would
-     * otherwise open. {@code consideringOnlyDependenciesInLayers} ignores dependencies of any class
-     * that matches no layer, so a package outside the nine - {@code io.restest.model}, or
-     * {@code io.restest.oracle} written in the singular - would have every one of its dependencies
-     * unchecked while the build stayed green. Requiring every class to belong to a layer turns that
-     * silent gap into a failure that names the package.
+     * <p>{@code ensureAllClassesAreContainedInArchitecture} closes a gap that would otherwise exist.
+     * {@code consideringOnlyDependenciesInLayers} ignores dependencies of any class that matches no
+     * layer, so a package outside the nine module packages this project uses - a misspelling, for
+     * example - would have every one of its dependencies unchecked while the build stayed green.
+     * Requiring every class to belong to a layer turns that silent gap into a failure that names the
+     * package.
      *
-     * <p>A consequence worth knowing before meeting it: this also rejects a class placed directly in
-     * {@code io.restest}, a root {@code package-info} included, because that package is not one of
-     * the nine modules. That is the intended reading of ADR-0004 - every class belongs to a module -
-     * and not an oversight. If a genuine root-level class is ever wanted, add it through
-     * {@code ensureAllClassesAreContainedInArchitectureIgnoring} deliberately rather than widening
-     * a layer to accommodate it.
+     * <p>A consequence worth knowing before meeting it: this also rejects a class placed directly
+     * outside all nine module packages, a root package-level file included. That is the intended
+     * reading of the rule - every class belongs to a module - and not an oversight.
      */
     static ArchRule dependenciesPointInwards(String root) {
         LayeredArchitecture architecture = Architectures.layeredArchitecture()
@@ -103,9 +102,10 @@ final class ArchitectureRules {
     }
 
     /**
-     * ADR-0007: the third-party specification parser is confined to one module, so replacing it is a
-     * module-sized change. The forbidden package is a parameter so the self-test can point the same
-     * rule at something it can actually depend on without dragging swagger-parser into this module.
+     * The third-party library that reads OpenAPI documents is confined to one module, so replacing it
+     * later is a change limited to that one module. The forbidden package is a parameter so the
+     * self-test can point the same rule at something it can actually depend on, without needing that
+     * real third-party library itself.
      */
     static ArchRule onlyOneModuleDependsOn(String root, String module, String forbiddenPackage) {
         return noClasses()
@@ -117,9 +117,9 @@ final class ArchitectureRules {
     }
 
     /**
-     * ADR-0004 and design principle 9: RESTest is usable as a library, so nothing but the
-     * command-line module may end the JVM. A library that ends the process takes its host down
-     * with it.
+     * RESTest is usable as a library, embedded inside someone else's program, so nothing but its own
+     * command-line module may end the whole process. A library that ends the process takes its host
+     * program down with it.
      */
     static ArchRule onlyOneModuleMayTerminateTheProcess(String root, String module) {
         return noClasses()
@@ -148,8 +148,8 @@ final class ArchitectureRules {
      * <p>The {@code ProcessHandle} clause is narrowed, for a reason that would otherwise surface as
      * a false positive in someone else's pull request. {@code processHandle.destroy()} reads
      * identically in bytecode whether the handle is this JVM's or a child process's: both are an
-     * {@code invokeinterface} on {@code java.lang.ProcessHandle}. Killing a child is legitimate and
-     * necessary - the out-of-process transport at M6.2 has to reap its helper - so flagging every
+     * {@code invokeinterface} on {@code java.lang.ProcessHandle}. Killing a child process is
+     * legitimate and sometimes necessary, and does not end our own process, so flagging every
      * {@code destroy} would fail correct code, and a rule that fails correct code gets switched off.
      * The clause therefore fires only where the same class also calls {@code ProcessHandle.current()},
      * which is the only way to obtain a handle on this JVM. Both shapes have fixtures: one that
@@ -192,20 +192,20 @@ final class ArchitectureRules {
     }
 
     /**
-     * Design principle 6: "No global mutable state. Two runs must coexist in one JVM." A static
-     * field that one run can write is a channel through which it can corrupt another.
+     * "No global mutable state. Two runs must coexist in one JVM." A static field that one run can
+     * write to is a channel through which it can corrupt another run happening at the same time.
      *
      * <p>Synthetic fields are excluded, which narrows the rule to what a person can actually write.
-     * The exclusion is not theoretical tidiness: it was added at M1.1a after the first production
-     * enum switch arrived. A switch over an enum makes the compiler generate a lookup table, and the
-     * two compilers this repository meets disagree about it. {@code javac} puts a
+     * The exclusion is not theoretical tidiness: it was added after the first production enum switch
+     * arrived. A switch over an enum makes the compiler generate a lookup table, and the two
+     * compilers this repository meets disagree about it. {@code javac} puts a
      * {@code static final int[] $SwitchMap$...} on a synthetic nested class - final, no violation.
      * The Eclipse compiler, which is what an IDE writes into {@code target/classes} when it builds
      * alongside Maven, puts a {@code private static volatile int[] $SWITCH_TABLE$...} on the enum
      * itself - not final, and reported.
      *
      * <p>The rule would therefore have failed for any contributor whose IDE compiled last, naming
-     * their enum switch as a breach of design principle 6. Nothing about that report would have been
+     * their enum switch as global mutable state. Nothing about that report would have been
      * actionable: the field is not in the source, and no run can reach it. A rule that fails correct
      * code gets switched off, and then it guards nothing.
      *
@@ -246,9 +246,8 @@ final class ArchitectureRules {
      */
 
     /**
-     * ADR-0004: "restest-core: domain model and interfaces. No network, no parser, no heavy
-     * dependencies." The rule states the "no network" half, which is the one a well-meaning change
-     * is most likely to breach.
+     * The domain-model module holds no network, parser or other heavy dependency. This checks the
+     * "no network" half, which is the one a well-meaning change is most likely to breach by accident.
      */
     static ArchRule moduleHoldsNoDependencyOn(String root, String module, String... forbidden) {
         DescribedPredicate<JavaClass> forbiddenPackages = resideInAnyPackage(forbidden);

--- a/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRules.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRules.java
@@ -62,14 +62,17 @@ final class ArchitectureRules {
      *
      * <p>{@code ensureAllClassesAreContainedInArchitecture} closes a gap that would otherwise exist.
      * {@code consideringOnlyDependenciesInLayers} ignores dependencies of any class that matches no
-     * layer, so a package outside the nine module packages this project uses - a misspelling, for
-     * example - would have every one of its dependencies unchecked while the build stayed green.
-     * Requiring every class to belong to a layer turns that silent gap into a failure that names the
-     * package.
+     * layer, so a package outside the nine module packages this project uses - {@code io.restest.model}
+     * or {@code io.restest.oracle}, written in the singular by mistake, for example - would have
+     * every one of its dependencies unchecked while the build stayed green. Requiring every class to
+     * belong to a layer turns that silent gap into a failure that names the package.
      *
      * <p>A consequence worth knowing before meeting it: this also rejects a class placed directly
      * outside all nine module packages, a root package-level file included. That is the intended
-     * reading of the rule - every class belongs to a module - and not an oversight.
+     * reading of the rule - every class belongs to a module - and not an oversight. If a genuine
+     * root-level class is ever wanted, it should be added by deliberately exempting it (ArchUnit's
+     * {@code ensureAllClassesAreContainedInArchitectureIgnoring}), not by widening one of the layers
+     * below to make room for it.
      */
     static ArchRule dependenciesPointInwards(String root) {
         LayeredArchitecture architecture = Architectures.layeredArchitecture()

--- a/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRulesSelfTest.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRulesSelfTest.java
@@ -26,16 +26,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Proves that the rules in {@link ArchitectureRules} report violations, rather than merely passing.
+ * Proves that the rules in {@link ArchitectureRules} actually report violations, rather than merely
+ * passing.
  *
- * <p>This is the test that earns the harness its keep at M0.2. The production modules are empty, so
- * {@link ProductionArchitectureTest} currently checks nothing - a rule that matches no classes
- * passes whether it is correct or broken. Here each rule is pointed at
- * {@code io.restest.arch.fixtures.mirror}, a miniature of the nine-module layout whose classes
- * break the rules on purpose, and the test asserts the rule fails and names the offender.
+ * <p>A rule that matches no classes at all passes whether it is correctly written or broken, so
+ * trusting {@link ProductionArchitectureTest} alone would not be enough. Here each rule is instead
+ * pointed at {@code io.restest.arch.fixtures.mirror}, a miniature copy of the project's module
+ * layout whose classes break the rules on purpose, and the test asserts that the rule fails and
+ * names the offending class.
  *
- * <p>Without these assertions a typo in a package pattern would leave a permanently green build
- * guarding nothing, which is the exact failure mode ADR-0004 was written to prevent.
+ * <p>Without these assertions, a typo in a package pattern would leave a permanently green build
+ * that was silently guarding nothing.
  */
 class ArchitectureRulesSelfTest {
 

--- a/restest-arch-tests/src/test/java/io/restest/arch/ProductionArchitectureTest.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/ProductionArchitectureTest.java
@@ -24,23 +24,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Applies every rule in {@link ArchitectureRules} to the nine production modules.
+ * Applies every rule in {@link ArchitectureRules} to the project's real, production code.
  *
- * <p>Tests are excluded from the import, so the deliberate violations under
- * {@code io.restest.arch.fixtures} - which compile to {@code target/test-classes} - are invisible
- * here. {@link ArchitectureRulesSelfTest} is where those are used.
+ * <p>Test code is excluded from the import, so the small examples under
+ * {@code io.restest.arch.fixtures}, which deliberately break these rules, are invisible here.
+ * {@link ArchitectureRulesSelfTest} is where those are used instead, to prove the rules actually
+ * report what they claim to.
  *
- * <p>Until M1.1a the production modules contained nothing but {@code module-info.java}, and each
- * check here skipped with a stated reason rather than passing over an empty set - a green build that
- * guards nothing is the failure mode ADR-0004 exists to prevent. The domain model has since arrived,
- * so every check now runs against real classes and the skips are gone. What proved the rules worked
- * in the meantime, and still proves that each of them reports what it claims to, is
- * {@link ArchitectureRulesSelfTest}.
- *
- * <p>{@link HarnessCoverageTest} is what keeps this test honest from here on: it compares the
- * classes each module compiled against the classes this import actually contains, so a module that
- * quietly leaves the import - a dropped dependency, a mis-scoped jar - fails there instead of
- * silently shrinking the subject set here.
+ * <p>{@link HarnessCoverageTest} keeps this test honest: it compares the classes each module
+ * compiled against the classes this import actually contains, so a module that quietly drops out of
+ * the import - a missing dependency, a misconfigured build - fails there instead of silently
+ * shrinking what gets checked here.
  */
 class ProductionArchitectureTest {
 
@@ -89,13 +83,10 @@ class ProductionArchitectureTest {
     /**
      * Runs a rule against the production modules.
      *
-     * <p>{@code allowEmptyShould} stays on for a reason that outlasted M0.2: the modules fill in
-     * across different milestones, so a rule scoped to one of them - the parser confinement rule
-     * now that {@code restest-core} holds classes but {@code restest-spec} does not yet -
-     * legitimately has an empty subject set for a while. The case it must not excuse is every rule
-     * being empty at once, which stopped being possible when the domain model arrived: the
-     * inward-dependency rule and the no-network rule both have subjects now, and
-     * {@link HarnessCoverageTest} fails if the import ever loses a module.
+     * <p>{@code allowEmptyShould} stays on because the modules fill in one at a time as the project
+     * grows, so a rule scoped to a module that has no classes in it yet legitimately has nothing to
+     * check for a while. What it must not excuse is every rule being empty at once - and
+     * {@link HarnessCoverageTest} fails if the import ever silently loses a whole module.
      */
     private static void check(ArchRule rule) {
         rule.allowEmptyShould(true).check(productionClasses);

--- a/restest-arch-tests/src/test/java/io/restest/arch/PublishedBytecodeTest.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/PublishedBytecodeTest.java
@@ -34,20 +34,20 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Checks that the bytecode the build actually produces is Java 21, which is the whole of ADR-0003's
- * promise to library consumers.
+ * Checks that the compiled code the build actually produces is Java 21 bytecode, which is RESTest's
+ * promise to anyone using it as a library: it must run on a plain Java 21 installation, without
+ * requiring a newer version.
  *
- * <p>The promise is not abstract. A project on Java 21 cannot load a class compiled for 25 no matter
- * what that class does, so {@code maven.compiler.release=21} is the single setting standing between
- * RESTest and a large share of its potential users. A setting is easy to lose in a POM edit; the
- * class file header is the evidence.
+ * <p>The promise is not abstract. A project running Java 21 cannot load a class compiled for Java
+ * 25, no matter what that class does, so the build setting that targets Java 21 is the one thing
+ * standing between RESTest and a large share of its potential users. That setting is easy to lose by
+ * accident in a build-file edit; reading the actual class file header is the only real evidence it
+ * held.
  *
- * <p>Module descriptors are excluded for the reason given on {@link #MODULE_DESCRIPTOR}, so until
- * M1.1a - when the domain model became the first compiled code in the reactor - there was nothing
- * to measure and the scan reported as skipped rather than passing over an empty set. It now reads
- * real classes. The instrument it reads them with is itself calibrated by
- * {@link #reads_the_major_version_from_a_class_file_header()}, which checks the header reader
- * against bytes whose version is known.
+ * <p>Module descriptors are excluded for the reason given on {@link #MODULE_DESCRIPTOR}. The
+ * instrument this test reads class files with is itself checked by
+ * {@link #reads_the_major_version_from_a_class_file_header()}, which verifies the header reader
+ * against bytes whose version is already known.
  */
 class PublishedBytecodeTest {
 
@@ -64,8 +64,8 @@ class PublishedBytecodeTest {
      * module, compiles against it and runs code from it, because the module system reads descriptors
      * leniently. Asserting 65 here would therefore fail the build over something correct.
      *
-     * <p>Verified rather than assumed: a module compiled on JDK 25 with {@code --release 21} was run
-     * on JDK 21 as a named module during M0.2.
+     * <p>Verified rather than assumed: a module compiled on JDK 25 with {@code --release 21} was
+     * actually run on JDK 21 as a named module.
      */
     private static final String MODULE_DESCRIPTOR = "module-info.class";
 
@@ -97,8 +97,8 @@ class PublishedBytecodeTest {
     }
 
     /**
-     * Calibrates the header reader, so that the scan above is not the only thing standing behind
-     * ADR-0003's claim while the modules are still empty.
+     * Checks the header reader itself, so the scan above is not the only thing standing behind the
+     * claim that the published bytecode is Java 21.
      *
      * <p>A class file header is the magic number, then the minor version, then the major version -
      * six bytes, which is little enough to write out and know the answer in advance.

--- a/restest-arch-tests/src/test/java/io/restest/arch/SourceTreeRulesTest.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/SourceTreeRulesTest.java
@@ -42,19 +42,18 @@ import org.junit.jupiter.api.Test;
 class SourceTreeRulesTest {
 
     /**
-     * ADR-0011 and the hard rules in CLAUDE.md: the benchmark platform lives in {@code evaluation/},
-     * which is not a Maven module, and the tool must know nothing about it. CLAUDE.md phrases the
-     * rule as a search over {@code src/} that must return zero hits, which is what this test runs.
+     * The benchmark platform used to evaluate RESTest lives entirely under {@code evaluation/},
+     * outside the tool's own build, and the tool itself must know nothing about it. This test runs a
+     * search over {@code src/} that must return zero hits for its name.
      *
-     * <p>Checked as text rather than as a dependency because the danger is not only a compiled
-     * reference. A path, a property name or a comment that assumes the harness's layout couples the
-     * tool to it just as effectively, and no bytecode rule would see any of them. The POM files are
-     * scanned for the same reason: a Maven property pinning the harness's commit would couple the
-     * build to it while leaving every source file clean.
+     * <p>Checked as text rather than as a compiled dependency, because the danger is not only a
+     * compiled reference. A path, a property name or a comment that assumes the benchmark's layout
+     * couples the tool to it just as effectively, and no bytecode rule would see any of them. The
+     * build files are scanned for the same reason: a build property pinning the benchmark's version
+     * would couple the two while leaving every source file clean.
      *
-     * <p>{@code evaluation/} is excluded, and must be. ADR-0011 puts the harness there, so naming it
-     * inside that directory is the intended state rather than a violation - a rule that failed on
-     * ADR-sanctioned work would be weakened by the first person to hit it.
+     * <p>{@code evaluation/} itself is excluded, and must be: that is exactly where the benchmark
+     * platform is meant to live, so naming it inside that directory is expected, not a violation.
      */
     @Test
     @DisplayName("no benchmark platform is referenced anywhere under src (ADR-0011)")
@@ -73,9 +72,9 @@ class SourceTreeRulesTest {
     }
 
     /**
-     * ADR-0004: "Nine Maven modules, each with a module-info.java." The declaration is what makes
-     * the boundary compiled rather than conventional, so losing one silently turns a module back
-     * into a package.
+     * Every production module has a {@code module-info.java}. That file is what makes each module a
+     * real, enforced boundary rather than just a naming convention, so silently losing one would turn
+     * a module back into an ordinary package.
      *
      * <p>The module list is read from the aggregator POM rather than hard-coded, so a module added
      * later is covered without anyone remembering to extend this test.
@@ -101,9 +100,9 @@ class SourceTreeRulesTest {
     }
 
     /**
-     * Supply-chain hygiene, and the reason M0.2 lists it: a tag is a moving pointer. {@code @v5} can
-     * be repointed at any commit by whoever owns the action, so a workflow pinned to a tag runs
-     * whatever that account decides to publish tomorrow. A 40-character commit SHA cannot move.
+     * Supply-chain hygiene: a tag is a moving pointer. {@code @v5} can be repointed at any commit by
+     * whoever owns the action, so a workflow pinned to a tag runs whatever that account decides to
+     * publish tomorrow. A 40-character commit SHA cannot move.
      *
      * <p>Dependabot updates these pins, which is why the version belongs in a trailing comment: it
      * is what lets Dependabot tell a v5 pin from a v6 one. That comment is checked here too - both

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/core/CoreReachingOutward.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/core/CoreReachingOutward.java
@@ -19,7 +19,7 @@ import io.restest.arch.fixtures.mirror.spec.SpecType;
 
 /**
  * Violates {@code dependenciesPointInwards}: the core layer reaches out to the spec layer, which
- * ADR-0004 says may only be accessed by the command-line module.
+ * only the command-line module is allowed to depend on.
  */
 public final class CoreReachingOutward {
 

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/exec/ExecReapingAChildProcess.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/exec/ExecReapingAChildProcess.java
@@ -22,8 +22,8 @@ import java.io.IOException;
  *
  * <p>In bytecode this is indistinguishable from {@link ExecTerminatingByProcessHandle}: both are an
  * {@code invokeinterface} on {@code java.lang.ProcessHandle.destroy}. The difference is whose
- * process the handle refers to, and killing a child is legitimate - the out-of-process transport at
- * M6.2 must be able to reap its helper. The rule tells them apart by whether the class also calls
+ * process the handle refers to: killing a child process is legitimate, since it does not end our
+ * own process. The rule tells the two apart by whether the class also calls
  * {@code ProcessHandle.current()}, which this one does not.
  */
 public final class ExecReapingAChildProcess {

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/gen/GenSwitchingOverAnEnum.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/gen/GenSwitchingOverAnEnum.java
@@ -23,8 +23,8 @@ package io.restest.arch.fixtures.mirror.gen;
  * {@code javac} emits {@code static final int[] $SwitchMap$…} on a synthetic nested class - final,
  * and reported by nothing. The Eclipse compiler emits {@code private static volatile int[]
  * $SWITCH_TABLE$…} on the enclosing class itself, which is not final; that is what an IDE writes
- * into {@code target/classes} when it builds alongside Maven, and it is what made the rule fire on
- * {@code io.restest.core.model.ParameterStyle} at M1.1a.
+ * into {@code target/classes} when it builds alongside Maven, and it is what once made this rule
+ * fire on an ordinary switch over {@code io.restest.core.model.ParameterStyle}.
  *
  * <p>So this fixture is the one that fails if the synthetic exclusion is removed - under a compiler
  * that emits the non-final form. Under {@code javac} the generated field is final and the

--- a/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/gen/GenWithStaticMutableState.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/fixtures/mirror/gen/GenWithStaticMutableState.java
@@ -16,8 +16,8 @@
 package io.restest.arch.fixtures.mirror.gen;
 
 /**
- * Violates {@code noStaticMutableState}: a static field one run can write is a channel through which
- * it can corrupt another, which design principle 6 forbids.
+ * Violates {@code noStaticMutableState}: a static field one run can write to is a channel through
+ * which it can corrupt another run happening at the same time.
  */
 public final class GenWithStaticMutableState {
 

--- a/restest-core/src/main/java/io/restest/core/execution/BodyValue.java
+++ b/restest-core/src/main/java/io/restest/core/execution/BodyValue.java
@@ -19,25 +19,20 @@ import io.restest.core.json.JsonValue;
 import java.util.Objects;
 
 /**
- * The request body chosen for a {@link TestCase}, when the operation takes one.
+ * The request body chosen for one {@link TestCase}, for an operation that takes one.
  *
- * <p>{@code mediaType} is kept as chosen, not normalised: it is not a lookup key here the way
- * {@link io.restest.core.model.RequestBodyModel#schemaFor(String)}'s argument is, it is the
- * media type this attempt actually used, and whoever judges it against the declared shape
- * normalises at that point.
+ * <p>{@code mediaType} is kept exactly as chosen for this attempt, not adjusted in any way; matching
+ * it against what the API's specification declares is a separate step, done elsewhere.
  *
- * <p>{@code origin} is one {@link ValueOrigin} for the whole body, not one per field. A body whose
- * fields come from several places at once - {@code {"id": <derived from the resource just created>,
- * "name": <generated>}}, the ordinary shape of an update in a CRUD sequence - cannot have that
- * distinction recorded here; the store can say the body as a whole was, say, partly derived, but
- * not which field. Recording per-field provenance inside a JSON document is a real design question
- * - it needs an annotated-value shape this record does not have - and it belongs with M2.5, which
- * builds request-body generation, or with M4 once a generator actually produces such bodies. Nothing
- * here should be read as having solved it.
+ * <p>{@code origin} records where the body as a whole came from, not a separate origin for each of
+ * its fields. A body can well have fields that came from different places at once - for example, an
+ * identifier read from an earlier response and a name that was freely generated - but this record
+ * cannot yet say which field came from where, only that the body as a whole was, say, partly derived
+ * from an earlier response. Recording each field's own origin is a more advanced feature this record
+ * does not attempt yet.
  *
- * <p>{@code value} is a {@link JsonValue}, which is as far as this increment's scope goes: the form
- * and multipart bodies M2.5 adds are not representable yet, and this record is not where that arrives
- * either - it is extended, or given siblings, once M2.5 defines what those bodies need.
+ * <p>{@code value} only represents bodies that are plain JSON for now. Bodies sent as web forms or as
+ * file uploads are not represented by this type yet either.
  *
  * @param mediaType the media type the body was sent as
  * @param value the body's content, before serialisation

--- a/restest-core/src/main/java/io/restest/core/execution/HttpRequestRecord.java
+++ b/restest-core/src/main/java/io/restest/core/execution/HttpRequestRecord.java
@@ -21,16 +21,15 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * The request as it actually went out: the method, the resolved URL and the exact headers and body -
- * not the operation's template, the values already substituted in.
+ * A request exactly as it was actually sent to the API: the method, the final URL, and the exact
+ * headers and body - with every value already filled in, not the operation's template.
  *
- * <p>This is the request for whichever attempt the {@link Interaction} it belongs to represents.
- * Nothing here decides, on its own, what "one attempt" means when the engine follows a redirect:
- * {@link Interaction}'s Javadoc says plainly that the engine is free to record each hop as its own
- * interaction, in which case this is that hop's own request, or to fold a whole redirect chain into
- * one interaction, in which case this is the first request of the chain and the outcome is the
- * chain's final result. Either way, this record is one HTTP request, exactly as it was sent - which
- * is also what a {@code curl} reproduction (M3.6) needs to show for whichever request it names.
+ * <p>This is the request belonging to whichever {@link Interaction} it is part of. If the HTTP
+ * client follows a redirect, it may record each hop as its own interaction, in which case this is
+ * that one hop's request, or it may fold a whole redirect chain into a single interaction, in which
+ * case this is the first request of the chain. Either way, this record always describes one HTTP
+ * request, exactly as it was sent - which is also what letting someone reproduce a request by hand
+ * (for example as a {@code curl} command) needs to show.
  *
  * @param method the HTTP method used
  * @param url the exact URL requested, path parameters substituted and the query string appended
@@ -62,14 +61,13 @@ public record HttpRequestRecord(HttpMethod method, String url, List<Header> head
     }
 
     /**
-     * The method, the URL, the sent headers' *names* and the body's own summary - never a header's
-     * value. A record's generated {@code toString} would print every header verbatim, and a header
-     * is exactly where an {@code Authorization} bearer token or an API key (M2.6) is carried; a log
-     * line or a report that prints an interaction must not repeat one back.
+     * The method, the URL, the *names* of the headers that were sent, and a summary of the body -
+     * but never a header's value. Headers commonly carry credentials such as an {@code Authorization}
+     * token or an API key, so a log line or report that prints an interaction must not repeat one
+     * back by accident.
      *
-     * <p>This does not solve secret redaction in general - a credential inside a query string or a
-     * request body is not caught by it, and doing that properly needs the request's meaning, not
-     * just its shape. That is left to the reporting work in M3.6.
+     * <p>This does not protect every kind of secret - a credential placed inside a query string or a
+     * request body is not caught by this alone.
      */
     @Override
     public String toString() {

--- a/restest-core/src/main/java/io/restest/core/execution/HttpResponseRecord.java
+++ b/restest-core/src/main/java/io/restest/core/execution/HttpResponseRecord.java
@@ -20,16 +20,15 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * A well-formed response, as it was actually received: the status line, headers and body verbatim.
+ * A well-formed HTTP response, exactly as it was received: the status, headers and body, verbatim.
  *
- * <p>This is what {@link InteractionOutcome.Answered} carries. A response that broke HTTP framing
- * before it could be read as one is not this type at all - see
- * {@link InteractionOutcome.MalformedResponse}, which is what {@code Answered} does not have to
- * account for.
+ * <p>This is what {@link InteractionOutcome.Answered} carries: a response that arrived and could be
+ * read as valid HTTP. A response so broken that it could not even be parsed as HTTP is a different
+ * type entirely - see {@link InteractionOutcome.MalformedResponse}.
  *
- * <p>The status code is kept exactly as received, with no range check. A server sending something
- * outside 100-599 is itself a fault - HTTP-semantics oracles report it from M3.2 - and a model that
- * refused to hold the observation could not report the very thing it was sent to catch.
+ * <p>The status code is kept exactly as received, with no range check. A server sending a status
+ * code outside the normal 100-599 range is itself misbehaving, and that is exactly the kind of fact
+ * RESTest exists to catch and report, so this type must be able to hold it rather than reject it.
  *
  * @param statusLine the status code and whatever else of the status line the engine reports
  * @param headers the headers received, in wire order, repeats kept

--- a/restest-core/src/main/java/io/restest/core/execution/Interaction.java
+++ b/restest-core/src/main/java/io/restest/core/execution/Interaction.java
@@ -22,31 +22,31 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * What we did to the API, and what came back: one {@link TestCase}, sent, and its outcome.
+ * A record of one real attempt to call the API: which {@link TestCase} was sent, the exact request
+ * that went out, and what came back.
  *
- * <p>ADR-0006 requires every interaction to be persisted - "exact request and response bytes,
- * timings, the test case that produced it, and the provenance of each parameter value" - and this is
- * that record. The engine (M1.3) constructs one per attempt; the store (M1.4) persists it unchanged;
- * oracles (M1.6) judge it; {@code restest recheck} (M3.3) re-judges a stored one against a different
- * oracle set, offline.
+ * <p>Every time RESTest actually sends a request to the API being tested, it keeps one of these:
+ * the exact bytes sent and received, how long it took, which test case produced the request, and
+ * where every value in that request came from. This is the record that gets saved, that a later
+ * check (a "did the API answer correctly?" judgement) is made against, and that can be re-examined
+ * later without sending the request again.
  *
- * <p>An {@code Interaction} exists only for an attempt that was actually sent. A {@link TestCase}
- * the engine planned but shed under adaptive concurrency or never reached before the budget ran out
- * produces no interaction at all - there is no request to describe and no outcome to report, so
- * inventing one would mean fabricating {@link #sentAt()}. Counting "planned versus attempted" is the
- * engine's and the report's job (M1.3, M3.6).
+ * <p>An {@code Interaction} exists only for a request that was genuinely sent. A {@link TestCase}
+ * that was planned but never actually attempted - for example because time ran out first - produces
+ * no interaction at all: there is nothing to describe and nothing to report, so none is invented.
  *
- * <p>Nothing here constrains how many interactions one {@link TestCase} may end up producing - a
- * retry, a replay, a redirect the engine chooses to record as its own attempt rather than fold into
- * one outcome are all the engine's and the store's business, not a shape this record has to
- * anticipate. That is what {@link ValueOrigin.Derived} points at an {@link InteractionId} rather than
- * at a {@link TestCase}'s own identity for: it names the one interaction whose data was actually
- * read, which stays meaningful whatever else happens to the test case that produced it.
+ * <p>Nothing here limits how many interactions one {@link TestCase} may end up producing: a retry, a
+ * repeated attempt, or a redirect followed by the underlying HTTP client can each become their own
+ * interaction. That flexibility is why, when one step's value is read from an earlier response (see
+ * {@link ValueOrigin.Derived}), it points at the identifier of that specific interaction rather than
+ * at the test case that produced it - it keeps naming the one exchange whose data was actually used,
+ * whatever else later happens to the test case.
  *
- * <p>A stateful step's {@link Interaction} is otherwise not a different shape from a stateless one's
- * - it is one whose {@link TestCase} happens to carry a {@link ValueOrigin.Derived}. A chain of steps
- * is a chain of {@link InteractionId}s, discoverable from the store, rather than a container this
- * type introduces.
+ * <p>A step that depends on an earlier one (a "stateful" step - for example, creating something and
+ * then reading it back) is not a different kind of interaction. It is simply one whose
+ * {@link TestCase} happens to use a value read from an earlier interaction. A whole chain of such
+ * steps is just a chain of interaction identifiers, not a separate structure this type needs to
+ * represent.
  *
  * @param id this interaction's identity, stable across storage and re-analysis
  * @param testCase the test case that produced this attempt

--- a/restest-core/src/main/java/io/restest/core/execution/Interaction.java
+++ b/restest-core/src/main/java/io/restest/core/execution/Interaction.java
@@ -27,9 +27,9 @@ import java.util.Optional;
  *
  * <p>Every time RESTest actually sends a request to the API being tested, it keeps one of these:
  * the exact bytes sent and received, how long it took, which test case produced the request, and
- * where every value in that request came from. This is the record that gets saved, that a later
- * check (a "did the API answer correctly?" judgement) is made against, and that can be re-examined
- * later without sending the request again.
+ * where every value in that request came from. This is meant to be the record that gets saved, that
+ * a later check (a "did the API answer correctly?" judgement) is made against, and that can be
+ * re-examined afterwards without sending the request again.
  *
  * <p>An {@code Interaction} exists only for a request that was genuinely sent. A {@link TestCase}
  * that was planned but never actually attempted - for example because time ran out first - produces

--- a/restest-core/src/main/java/io/restest/core/execution/InteractionOutcome.java
+++ b/restest-core/src/main/java/io/restest/core/execution/InteractionOutcome.java
@@ -62,7 +62,10 @@ public sealed interface InteractionOutcome {
      * is shorter than its declared length, or a chunked transfer never sends its final chunk. Judging
      * that properly needs everything the response claimed about itself: the protocol version and
      * reason phrase as well as the reason text, since which failures are even possible depends on the
-     * protocol in use.
+     * protocol in use - chunked encoding, for instance, only exists under HTTP/1.1. {@code statusLine}
+     * is a single optional value rather than three separate ones for the same reason: a reason phrase
+     * or protocol version parsing while the status code itself did not is not a shape HTTP can
+     * actually produce, and {@link StatusLine} keeps that impossible shape from being built at all.
      *
      * <p>{@code partial}'s stored length, if set, means only "our own storage kept fewer bytes than
      * were actually delivered" - never "the response claimed more than it delivered". That second,
@@ -76,7 +79,9 @@ public sealed interface InteractionOutcome {
      *     without a final zero-length chunk", not a stack trace
      * @param statusLine the status code and whatever else parsed, when the status line parsed at all
      * @param headers the headers, when they parsed, in wire order, repeats kept
-     * @param partial whatever body bytes were received before the exchange broke, when any were
+     * @param partial whatever body bytes were received before the exchange broke, when any were.
+     *     Declared under {@link Payload#UNKNOWN_MEDIA_TYPE} when nothing said what they were meant to
+     *     be, rather than guessing at a {@code Content-Type} the response may never have sent
      */
     record MalformedResponse(String reason, Optional<StatusLine> statusLine, List<Header> headers,
             Optional<Payload> partial) implements InteractionOutcome {

--- a/restest-core/src/main/java/io/restest/core/execution/InteractionOutcome.java
+++ b/restest-core/src/main/java/io/restest/core/execution/InteractionOutcome.java
@@ -20,25 +20,26 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * What happened when a {@link TestCase} was sent.
+ * What happened when RESTest actually sent a {@link TestCase} to the API: a proper answer, a
+ * broken one, or no answer at all.
  *
- * <p>Three outcomes, not two, because they are different facts for an oracle and conflating any
- * pair of them hides one. A well-formed response the wrong shape is the API's fault, and most
- * oracles (M1.6's schema-conformance oracle among them) need {@link Answered} to have anything to
- * judge. A response that is not well-formed HTTP at all - broken chunked encoding, a truncated
- * status line, a body shorter than its own declared {@code Content-Length} - is also the API's
- * fault, and a different one: the HTTP-semantics oracles WFC reserves codes 900-909 for (M3.2) exist
- * specifically to report it, and they cannot fire on an outcome that looks identical to a dropped
- * connection. No response at all - refused, timed out, a broken TLS handshake - is a fact about the
- * attempt, not about the API, and is the one case with nothing to show an oracle.
+ * <p>These are three different situations, and treating any two of them as the same would hide real
+ * information. A well-formed response with the wrong content is the API misbehaving in the ordinary
+ * sense, and is what most checks need in order to judge anything at all - see {@link Answered}. A
+ * response that is not even valid HTTP - broken chunked encoding, a cut-off status line, a body
+ * shorter than the length it declared - is also the API's fault, but a different and more serious
+ * one, deserving its own report rather than being confused with a connection that simply dropped -
+ * see {@link MalformedResponse}. Getting no response at all - refused, timed out, a broken
+ * connection - is a fact about the attempt itself, not about the API, and is the one case with
+ * nothing to actually check - see {@link TransportFailure}.
  *
- * <p>Sealed over exactly these three, so an oracle or a report that means to handle one case gets a
- * compiler error if a fourth is ever added, rather than quietly doing nothing useful with it.
+ * <p>These are the only three possibilities, which the compiler enforces: code meant to handle one
+ * outcome must handle all three, rather than silently doing nothing useful if a fourth is ever
+ * added.
  *
- * <p>Not represented here: a {@link TestCase} the engine planned but never attempted at all - shed by
- * adaptive concurrency, cut off by the budget running out. That is not an outcome of sending a
- * request; nothing was sent, so no {@link Interaction} exists for it. A run's accounting of "planned
- * versus attempted" is the engine's and the report's to keep (M1.3, M3.6), not a fourth case here.
+ * <p>Not represented here: a {@link TestCase} that was planned but never actually attempted, for
+ * example because time ran out first. That is not an outcome of sending a request at all - nothing
+ * was sent, so no {@link Interaction} exists for it either.
  */
 public sealed interface InteractionOutcome {
 
@@ -54,36 +55,28 @@ public sealed interface InteractionOutcome {
     }
 
     /**
-     * Bytes came back, but they were not a well-formed HTTP response.
+     * Bytes came back, but they did not form a well-formed HTTP response.
      *
-     * <p>The status line and the headers are kept separately from {@code partial}, not folded into
-     * it, because the common shape of this outcome parses both cleanly and only the body breaks - a
-     * declared {@code Content-Length} the actual bytes fall short of, a chunked stream that never
-     * sends its final chunk. An oracle judging that (M3.2, WFC 900-909) needs what the response
-     * claimed about itself, not only the reason text - the protocol version and reason phrase
-     * included, since whether a given framing failure is even possible (chunked encoding exists only
-     * under HTTP/1.1) depends on which protocol was in use. {@code statusLine} is one optional
-     * component, not three: a reason phrase or a protocol version parsing while the status code did
-     * not is not a shape HTTP itself can produce, and {@link StatusLine} makes that shape
-     * unconstructable instead of merely undocumented.
+     * <p>The status line and the headers are kept separately from {@code partial}, because in the
+     * usual shape of this failure both parse cleanly and only the body is broken - for example, it
+     * is shorter than its declared length, or a chunked transfer never sends its final chunk. Judging
+     * that properly needs everything the response claimed about itself: the protocol version and
+     * reason phrase as well as the reason text, since which failures are even possible depends on the
+     * protocol in use.
      *
-     * <p>{@code partial}'s {@link Payload#wireLength()}, if set, means only "our own storage kept
-     * fewer bytes than were actually delivered" - never "the response claimed more than it
-     * delivered". That second fact, a declared length the API failed to honour, is already visible
-     * by comparing {@link Payload#deliveredLength()} - not {@link Payload#size()}, which understates
-     * delivery whenever this payload was also cut short by our own storage - against a
-     * {@code Content-Length} in {@code headers}; it is not this field's job to restate it. Bytes that
-     * simply stopped arriving, with no declared length to compare against - a chunked stream with no
-     * final chunk - are exactly what {@code partial} with no {@code wireLength} represents: everything
-     * we have, with nothing said about whether more was coming.
+     * <p>{@code partial}'s stored length, if set, means only "our own storage kept fewer bytes than
+     * were actually delivered" - never "the response claimed more than it delivered". That second,
+     * separate fact - a declared length the API failed to honour - is checked by comparing what was
+     * actually delivered against the {@code Content-Length} already present in {@code headers}; it is
+     * not this field's job to restate it. Bytes that simply stopped arriving, with no declared length
+     * to compare against, are exactly what {@code partial} with no stored length represents:
+     * everything we have, with no claim about whether more was coming.
      *
      * @param reason what was wrong, in a form fit to print in a report - "chunked encoding ended
      *     without a final zero-length chunk", not a stack trace
      * @param statusLine the status code and whatever else parsed, when the status line parsed at all
      * @param headers the headers, when they parsed, in wire order, repeats kept
-     * @param partial whatever body bytes were received before the exchange broke, when any were.
-     *     Declared under {@link Payload#UNKNOWN_MEDIA_TYPE} when nothing said what they were meant
-     *     to be, rather than repeating a {@code Content-Type} the response may never have sent
+     * @param partial whatever body bytes were received before the exchange broke, when any were
      */
     record MalformedResponse(String reason, Optional<StatusLine> statusLine, List<Header> headers,
             Optional<Payload> partial) implements InteractionOutcome {

--- a/restest-core/src/main/java/io/restest/core/execution/Payload.java
+++ b/restest-core/src/main/java/io/restest/core/execution/Payload.java
@@ -35,10 +35,11 @@ import java.util.Optional;
  * never mixed: a header stating the encoded size cannot be meaningfully compared against a decoded
  * body's length.
  *
- * <p>{@code wireLength} exists because RESTest can be configured to store only part of a very large
- * body, to save space. When that happens, {@code content} holds less than the API actually sent, and
- * this field records how much was truly delivered - so that a stored body being shorter than
- * expected is never mistaken for the API itself having sent a broken response. That is a separate
+ * <p>{@code wireLength} exists because RESTest is meant to be able to keep only part of a very
+ * large body, to save space, rather than being forced to keep everything or nothing. When that
+ * happens, {@code content} holds less than the API actually sent, and this field records how much
+ * was truly delivered - so that a stored body being shorter than expected is never mistaken for the
+ * API itself having sent a broken response. That is a separate
  * concern from whether the API's own {@code Content-Length} header matches what it actually sent;
  * that comparison is made using the headers kept alongside this payload, not through this field.
  * {@link #truncated()} answers only "did our own storage cut this short". Bytes that simply stopped

--- a/restest-core/src/main/java/io/restest/core/execution/Payload.java
+++ b/restest-core/src/main/java/io/restest/core/execution/Payload.java
@@ -21,54 +21,41 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Exact bytes, with their declared media type.
+ * The exact bytes of a request or response body, together with the media type (such as
+ * {@code application/json}) they were sent or received under.
  *
- * <p>This is what "exact wire capture" (M1.3) and "exact request and response payloads" (this
- * increment's own entry in {@code ROADMAP.md}) mean as a type: a request or response body kept
- * byte-for-byte, not re-derived from a parsed model of it. A schema-conformance oracle (M1.6) needs
- * the bytes actually received, not a JSON tree that normalises away whatever made the response
- * malformed in the first place.
+ * <p>When RESTest sends a request to an API or reads its response, it keeps the body exactly as it
+ * was on the wire, byte for byte - it does not reinterpret it into some parsed form first. This
+ * matters because checking whether a response matches what the API's specification promises needs
+ * the bytes actually received, not a version that has already been cleaned up and might hide the
+ * very problem being looked for.
  *
- * <p>{@code content} and {@code wireLength}, when the latter is present, refer to the same
- * representation of the body - whichever one the engine actually read. An HTTP client ordinarily
- * hands back content already decoded from {@code Content-Encoding} and dechunked, and that is the
- * ordinary case here too; what matters is that the engine never mixes a decoded {@code content} with
- * an encoded {@code wireLength} or the reverse; a {@code Content-Length} header counts encoded
- * octets, and comparing it against a decoded length is meaningless.
+ * <p>{@code content} and {@code wireLength} always describe the same version of the body - typically
+ * already decoded and reassembled by the underlying HTTP client. What matters is that the two are
+ * never mixed: a header stating the encoded size cannot be meaningfully compared against a decoded
+ * body's length.
  *
- * <p>{@code wireLength} exists because ADR-0006 names "configurable response-body truncation" as the
- * store's (M1.4) answer to storage cost - so a stored payload is not always the whole body, and a
- * record silent about that would have an oracle read a cut-off document, fail to parse it, and
- * report a fault the API never committed. It says only that: how much of what was genuinely
- * delivered got kept. A previous version of this field also doubled as "how much the response
- * claimed it would send" - the fact a body cut short by a declared {@code Content-Length} needs -
- * and that conflated two different events under one number: our own storage policy, and a fault of
- * the API's. They are kept apart. What the API declared is read from the {@code Content-Length}
- * header, already present wherever this type is used alongside headers
- * ({@link InteractionOutcome.MalformedResponse}); {@code wireLength} here answers only "did our own
- * retention cut this short", which is a boolean question with one number behind it rather than two
- * that could disagree - {@link #truncated()} is derived from it, not stored beside it. Bytes that
- * simply stopped arriving with nothing to compare them against - a chunked stream with no final
- * chunk - are {@code content} with no {@code wireLength} at all: everything retained, nothing said
- * about whether more was coming.
+ * <p>{@code wireLength} exists because RESTest can be configured to store only part of a very large
+ * body, to save space. When that happens, {@code content} holds less than the API actually sent, and
+ * this field records how much was truly delivered - so that a stored body being shorter than
+ * expected is never mistaken for the API itself having sent a broken response. That is a separate
+ * concern from whether the API's own {@code Content-Length} header matches what it actually sent;
+ * that comparison is made using the headers kept alongside this payload, not through this field.
+ * {@link #truncated()} answers only "did our own storage cut this short". Bytes that simply stopped
+ * arriving, with nothing to compare them against, are recorded as {@code content} with no
+ * {@code wireLength} at all: everything that was kept, with no claim about whether more was coming.
  *
- * <p>An oracle comparing what the API declared against what it delivered must use
- * {@link #deliveredLength()}, never {@link #size()}. {@code size()} is how much *this payload holds*,
- * which is smaller than what was delivered whenever our own storage truncated it - comparing that
- * number against a {@code Content-Length} would blame the API for our retention policy.
- * {@code deliveredLength()} corrects for exactly that, and reduces to {@code size()} when nothing was
- * further truncated. Neither number is meaningful against a {@code Content-Length} that counts
- * encoded octets while {@code content} holds a decoded body - the same content-coding warning above
- * applies to this comparison too, and is the engine's to get right, not this record's to enforce.
+ * <p>Code comparing what an API declared against what it delivered should use
+ * {@link #deliveredLength()}, not {@link #size()}. {@code size()} is only how many bytes this record
+ * itself is holding, which can be smaller than what was truly delivered when storage has trimmed it;
+ * comparing that number against a declared length would unfairly blame the API for our own storage
+ * choice. {@code deliveredLength()} accounts for that, and is identical to {@code size()} when
+ * nothing was trimmed.
  *
- * <p>This is the first record in {@code restest-core} holding a mutable component - not the case the
- * {@code TODO} on {@code ArchitectureRules.noStaticMutableState} was left for, since that gap is
- * about {@code static final} fields and this is an instance field, but the same discipline applies:
- * no static analysis of a compact constructor can tell "copies the array" from "keeps the reference",
- * so it is enforced by convention and by the test below, not mechanically. The convention: clone on
- * the way in, clone on the way out, and override {@code equals}/{@code hashCode} by hand - the ones a
- * record generates for an array component compare references, which is silently wrong for two
- * payloads with identical content built from two different arrays.
+ * <p>This is the first place in this module where a value, once built, still contains an array
+ * (the raw bytes) that could in principle be changed after the fact from outside. That is guarded
+ * against by convention: the bytes are copied on the way in and on the way out, and equality is
+ * checked by comparing the bytes themselves rather than by reference - see the overrides below.
  *
  * @param content the exact bytes actually retained, defensively copied on construction and on every
  *     read - not necessarily the whole body; see {@link #wireLength()} and {@link #truncated()}

--- a/restest-core/src/main/java/io/restest/core/execution/StatusLine.java
+++ b/restest-core/src/main/java/io/restest/core/execution/StatusLine.java
@@ -35,10 +35,9 @@ import java.util.Optional;
  * @param statusCode the status code
  * @param reasonPhrase the reason phrase, when the protocol carries one and it parsed - HTTP/2 and
  *     HTTP/3 do not
- * @param protocolVersion the protocol version, as reported by the engine - {@code "HTTP/1.1"},
- *     {@code "HTTP/2"} - kept as a string for the same reason as
- *     {@link io.restest.core.schema.StringSchema#format()}: the engine (M1.3) reports whatever its
- *     own HTTP client calls the protocol, and the exact spelling is not this record's to standardise
+ * @param protocolVersion the protocol version, as reported by the HTTP client - {@code "HTTP/1.1"},
+ *     {@code "HTTP/2"} - kept as a plain string rather than a fixed set of values, since it is simply
+ *     reported as given and is not this record's job to standardise
  */
 public record StatusLine(int statusCode, Optional<String> reasonPhrase,
         Optional<String> protocolVersion) {

--- a/restest-core/src/main/java/io/restest/core/execution/TestCase.java
+++ b/restest-core/src/main/java/io/restest/core/execution/TestCase.java
@@ -24,32 +24,30 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * One concrete attempt to invoke an operation: which one, and what value for each of its inputs.
+ * One concrete test to run against the API: which operation to call, and what value to send for
+ * each of its inputs.
  *
- * <p>ADR-0005's whole decision is that this is data, executed directly by an HTTP client - never
- * generated source, never compiled. A {@code TestCase} is planned by the generator (M1.5), sent
- * unchanged by the engine (M1.3), and persisted unchanged by the store (M1.4); nothing about it is
- * regenerated between those steps.
+ * <p>A {@code TestCase} is plain data, not generated program code: it is built once by the part of
+ * RESTest that decides what to test, sent to the API unchanged, and saved unchanged afterwards.
+ * Nothing about it is regenerated or reinterpreted along the way, which is what lets a saved test
+ * case be re-examined, or re-sent, long after the run that created it has ended.
  *
- * <p>It names its operation by {@link OperationId} rather than holding the
- * {@link io.restest.core.model.Operation} itself, so that a test case read back by
- * {@code restest recheck} (M3.3) does not require the {@link io.restest.core.model.ApiModel} that
- * produced it still being in memory - the two are decoupled the same way a stored interaction is
- * decoupled from the run that created it.
+ * <p>It refers to its operation by {@link OperationId} rather than by holding the operation itself,
+ * so that a test case can be read back later without needing the whole API description that
+ * produced it still in memory - the two are kept independent, the same way a saved interaction stays
+ * usable independently of the run that created it.
  *
- * <p>{@link #id()} is built with everything else already decided, and there is deliberately no
- * {@code withX} method that would let a caller change the parameter values or the body of an
- * existing instance: {@link TestCaseId}'s own contract is an identity stable across generation,
- * execution and storage, and an identity that could be attached to two different sets of values
- * would not be stable at all - it is exactly the "answers its own lookup with whichever content was
- * built first" failure {@link #rejectDuplicateParameterValues} refuses one level down.
+ * <p>Once built, a test case cannot be changed: there is no method to replace its parameter values or
+ * body on an existing instance. Its identifier is meant to stay stable and always point at the same
+ * set of values, and allowing it to be attached to different values afterwards would break that
+ * guarantee.
  *
- * <p>A stateful step is not a different kind of test case. It is one whose {@link ParameterValue}s
- * or {@link #body()} carry a {@link ValueOrigin.Derived} instead of a {@link ValueOrigin.Generated}
- * or {@link ValueOrigin.Declared} - see {@link ValueOrigin}. A whole stateful test, in the sense
- * {@code docs/DESIGN.md}'s glossary uses the word - a sequence where each step depends on the last - is
- * the chain of {@code Derived} edges across several test cases and interactions, not a container
- * this type introduces.
+ * <p>A "stateful" step - one that depends on an earlier request, such as reading back something just
+ * created - is not a different kind of test case. It is simply one whose parameter values or body
+ * carry a {@link ValueOrigin.Derived} origin instead of a {@link ValueOrigin.Generated} or
+ * {@link ValueOrigin.Declared} one - see {@link ValueOrigin}. A whole sequence of dependent steps is
+ * just a chain of such derived values across several test cases and interactions, not something this
+ * type needs to represent as a group.
  *
  * @param id this test case's identity, stable across generation, execution and storage
  * @param operation which operation this attempts to invoke

--- a/restest-core/src/main/java/io/restest/core/execution/TestCaseId.java
+++ b/restest-core/src/main/java/io/restest/core/execution/TestCaseId.java
@@ -43,9 +43,8 @@ public record TestCaseId(String value) {
     /**
      * A fresh identifier.
      *
-     * <p>Random rather than sequential: two runs generating test cases concurrently - two JVMs, or
-     * two threads in one, which design principle 6 requires to coexist - must not race to hand out
-     * the same identifier.
+     * <p>Random rather than sequential: two runs generating test cases at the same time - whether two
+     * separate processes or two threads within one - must not race to hand out the same identifier.
      */
     public static TestCaseId generate() {
         return new TestCaseId(UUID.randomUUID().toString());

--- a/restest-core/src/main/java/io/restest/core/execution/ValueOrigin.java
+++ b/restest-core/src/main/java/io/restest/core/execution/ValueOrigin.java
@@ -18,35 +18,33 @@ package io.restest.core.execution;
 import java.util.Objects;
 
 /**
- * Where one chosen value came from.
+ * Where one specific value used in a test came from.
  *
- * <p>ADR-0006 promises that every run persists "the provenance of each parameter value"; this is
- * that promise as a type. A {@link TestCase} is a concrete, already-decided attempt - one value per
- * parameter, not a distribution of candidates - so provenance answers one question per value: which
- * of the three things that can produce a value produced this one.
- *
- * <p>The three cases are the whole of what a value can be, and the amendment to ADR-0005 explains
- * why each is shaped the way it is. In short:
+ * <p>RESTest keeps track of how every value it sends was chosen, so that a report or a person
+ * reading it later can tell whether a value came straight from the API's own documentation, was
+ * produced by a generator, or was taken from a previous request's response. A {@link TestCase} is a
+ * concrete, already-decided attempt - one specific value per input, not a range of possibilities -
+ * so this answers one simple question about each value: which of three things produced it.
  *
  * <ul>
- *   <li>{@link Declared} - taken from the schema's own default or enumeration
- *       ({@link io.restest.core.schema.SchemaMetadata}), stated by the document itself.</li>
- *   <li>{@link Generated} - produced by whichever stateless mechanism was tried: a random provider,
- *       a boundary walk, a value dictionary, an external provider. {@code source} is an open name
- *       rather than an enumerated set, because none of those mechanisms exist yet in {@code core}
- *       and ADR-0008 forbids naming them here even once they do.</li>
- *   <li>{@link Derived} - read out of an earlier interaction's response, which is what makes a
- *       stateful step representable: "the {@code petId} for this request is the {@code id} the
- *       server returned when we created the pet."</li>
+ *   <li>{@link Declared} - taken directly from the API's own specification: a default value or one
+ *       of a fixed list of choices it declares.</li>
+ *   <li>{@link Generated} - produced by RESTest itself, using whichever technique was tried: a
+ *       random value, a boundary case, a value picked from a dictionary, or a value supplied by an
+ *       external source. {@code source} names that technique in plain text rather than from a fixed
+ *       list, since RESTest is designed to support new techniques being added later.</li>
+ *   <li>{@link Derived} - read out of an earlier request's response. This is what makes it possible
+ *       to test a sequence of related requests: "the {@code petId} used in this request is the
+ *       {@code id} the server returned when we created the pet."</li>
  * </ul>
  *
- * <p>Which of the three wins for a given parameter, in a given run, is a generation-time decision -
- * M1.5's value-provider chain and M4.2's runtime resource pool and value-source selection - and
- * belongs to {@code restest-gen}, not here. This type only has to be able to name the winner
- * afterwards.
+ * <p>Deciding which of the three applies to a given value, in a given run, is a decision made while
+ * building the test case, elsewhere in RESTest. This type only has to be able to name, afterwards,
+ * which one won.
  *
- * <p>Sealed, so that a report or a metrics collector counting values by origin fails to compile
- * rather than silently miscounting the day a fourth case is added:
+ * <p>These three are the only possibilities, which is enforced by the compiler: any code that
+ * handles values by their origin must handle all three cases, or it will not compile, rather than
+ * silently ignoring a case that gets added later:
  *
  * {@snippet :
  * String describe(ValueOrigin origin) {
@@ -83,28 +81,18 @@ public sealed interface ValueOrigin {
     }
 
     /**
-     * Read out of an earlier interaction's response - the mechanism that makes a stateful step
-     * representable at all.
+     * A value read out of an earlier interaction's response - the mechanism that makes a "stateful"
+     * step (one that depends on an earlier request) possible at all.
      *
-     * <p>{@code from} names an {@link InteractionId}, not a {@link TestCaseId}. {@link TestCase}
-     * holds concrete, already-resolved values - never a placeholder to fill in later, per ADR-0005 -
-     * so a correct generator has no reason to build a {@code ParameterValue} carrying {@code Derived}
-     * before it has already read the response {@code value()} comes from: the value itself cannot be
-     * known any other way. That is a rule for the generator (M4.2) to keep, not a property this type
-     * enforces - nothing here stops a caller from minting an {@link InteractionId} early and naming
-     * it before the interaction exists, which would simply be a mistake with no data behind it, the
-     * same way naming an operation that does not exist would be. Given that a correct generator
-     * always has the interaction in hand already, {@link InteractionId} is the more useful pointer of
-     * the two: unlike a {@link TestCaseId}, it survives whatever the engine does afterwards with the
-     * test case that produced it - a retry, a replay, or nothing at all - because it names one
-     * specific interaction rather than "whichever interaction this test case eventually produces".
+     * <p>{@code from} names the specific {@link InteractionId} the value was read from, not the
+     * {@link TestCase} that produced that interaction. By the time this value exists, the response it
+     * was read from already happened, so pointing at the exact interaction is both accurate and more
+     * durable: it keeps meaning the same thing regardless of whatever RESTest later does with the
+     * test case that produced that interaction, such as retrying or repeating it.
      *
      * @param from the interaction this value was read from
      * @param description what was taken from it, for a human to read - "response body field 'id'" -
-     *     not a parseable expression. The extraction grammar a stateful generator actually uses (a
-     *     JSONPath, an OpenAPI {@code links} runtime expression, whatever the operation dependency
-     *     graph infers) is M4.1-4.3's decision, none of which exist yet; committing to one now would
-     *     mean guessing at a design several milestones away
+     *     rather than a machine-readable expression
      */
     record Derived(InteractionId from, String description) implements ValueOrigin {
         public Derived {

--- a/restest-core/src/main/java/io/restest/core/execution/ValueOrigin.java
+++ b/restest-core/src/main/java/io/restest/core/execution/ValueOrigin.java
@@ -85,10 +85,13 @@ public sealed interface ValueOrigin {
      * step (one that depends on an earlier request) possible at all.
      *
      * <p>{@code from} names the specific {@link InteractionId} the value was read from, not the
-     * {@link TestCase} that produced that interaction. By the time this value exists, the response it
-     * was read from already happened, so pointing at the exact interaction is both accurate and more
-     * durable: it keeps meaning the same thing regardless of whatever RESTest later does with the
-     * test case that produced that interaction, such as retrying or repeating it.
+     * {@link TestCase} that produced that interaction. Whatever builds this value correctly only ever
+     * does so after that interaction's response has actually been read, since the value itself cannot
+     * be known any other way - but nothing here enforces that: this type does not stop code from
+     * naming an interaction that has not happened yet, which would simply be a mistake with no real
+     * data behind it. Naming the interaction rather than the test case is still the better choice for
+     * a value built correctly, because it keeps meaning the same thing regardless of whatever RESTest
+     * later does with the test case that produced that interaction, such as retrying or repeating it.
      *
      * @param from the interaction this value was read from
      * @param description what was taken from it, for a human to read - "response body field 'id'" -

--- a/restest-core/src/main/java/io/restest/core/json/JsonValue.java
+++ b/restest-core/src/main/java/io/restest/core/json/JsonValue.java
@@ -23,21 +23,21 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * A JSON value: the six things a JSON document can hold, and nothing else.
+ * A piece of JSON data: a value that is a JSON null, a boolean, a number, a string, an array, or an
+ * object - the six things any JSON document is built from, and nothing else.
  *
- * <p>The model needs somewhere to put values that come from a specification - a schema's
- * {@code default}, the members of an {@code enum}, and from M2.2 the declared examples - and later
- * somewhere to build request bodies. Those values are JSON, so they are represented as JSON rather
- * than as {@code Object} with a comment explaining which classes are really allowed.
+ * <p>RESTest uses this to hold values that come from an API's specification - a field's default
+ * value, the fixed set of choices in an {@code enum}, a documented example - and later to build the
+ * bodies it sends in requests. Since these values are JSON, they are represented as JSON here
+ * instead of as a generic, loosely-typed value.
  *
- * <p>This is deliberately our own rather than a library's. ADR-0004 keeps heavy dependencies out of
- * {@code restest-core}, and a JSON library in the core would become part of the published surface
- * of every consumer, to be kept in step with whatever version they already use. Six records are
- * cheaper than that, and the parser module - which does have a JSON library - converts at the
- * boundary.
+ * <p>This is a small representation written for this project rather than borrowed from an external
+ * library, so that using RESTest never forces a consumer to also depend on some particular JSON
+ * library and keep it in sync with their own. The module that reads OpenAPI documents does use such
+ * a library, and converts into this type at the boundary.
  *
- * <p>Every variant is immutable, and the two that hold collections copy what they are given, so a
- * caller cannot change a value after handing it over.
+ * <p>Every variant is immutable, and the two that hold collections (arrays and objects) copy what
+ * they are given, so a caller cannot change a value after handing it over.
  *
  * <p>Reading a value means pattern matching, and the interface is sealed so the compiler can tell
  * you when you have missed a case:

--- a/restest-core/src/main/java/io/restest/core/model/ApiModel.java
+++ b/restest-core/src/main/java/io/restest/core/model/ApiModel.java
@@ -135,9 +135,11 @@ public record ApiModel(
      * <p>Everything downstream looks an operation up by its identifier - per-operation settings,
      * stored results, failure reports - and every one of them would silently get the wrong operation
      * if two shared an identifier. RESTest's rule is to never let a bad specification crash the
-     * tool, so instead of rejecting the whole document, the parser makes the identifier unique,
-     * records a {@link SpecificationIssue} saying so, and keeps both operations testable. What it may
-     * not do is hand over a model that cannot answer its own lookups.
+     * tool, so instead of rejecting the whole document outright, whatever builds this model from it
+     * is meant to make the identifier unique, record a {@link SpecificationIssue} saying so, and keep
+     * both operations testable. What it may not do is hand over a model that cannot answer its own
+     * lookups, which is why this constructor still rejects the duplicate rather than silently
+     * accepting it.
      */
     private static void rejectDuplicateIds(List<Operation> operations) {
         Map<OperationId, Operation> seen = new LinkedHashMap<>();

--- a/restest-core/src/main/java/io/restest/core/model/ApiModel.java
+++ b/restest-core/src/main/java/io/restest/core/model/ApiModel.java
@@ -25,17 +25,18 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * A whole API as the tool understands it: its operations, the shapes they share, and what could not
- * be read.
+ * One whole API, translated from its OpenAPI document into something the rest of RESTest can work
+ * with directly: every operation it offers, the data shapes those operations share, and a note of
+ * anything in the document that could not be understood.
  *
- * <p>This is the output of {@code restest-spec} and the input to everything else. Once it exists,
- * no part of the tool needs the document again, which is what ADR-0007 means by keeping the parser
- * behind a boundary: swapping the parser, or adding support for a new version of the format, changes
- * how this value is produced and nothing about how it is used.
+ * <p>This is what the module that reads OpenAPI documents produces, and everything else in RESTest -
+ * test generation, execution, reporting - builds on this instead of reading the original document
+ * again. That way, changing how documents are read, or adding support for a newer OpenAPI version,
+ * never affects how the rest of the tool uses the result.
  *
- * <p>It is immutable and holds no reference to anything global, so two models - two runs, two APIs,
- * two versions of one API - coexist in one JVM without interfering. That is design principle 6 at
- * the level of the data.
+ * <p>It never changes once built, and it does not depend on any shared or global state, so several
+ * of these can exist side by side - for two different runs, two different APIs, or two versions of
+ * the same API - without one interfering with another.
  *
  * @param title the API's name, as the document gives it
  * @param version the API's version, as the document gives it
@@ -131,13 +132,12 @@ public record ApiModel(
      * Two operations under one identifier is a contradiction, not a degradation, so it is refused
      * here rather than carried.
      *
-     * <p>The model is what the rest of the tool keys on: per-operation settings, stored
-     * interactions, failure reports and {@code restest recheck} all look an operation up by
-     * identifier, and every one of them would silently get the first of the two. Design principle 2
-     * is not in tension with this - it says skip the offending operation and report it, and that is
-     * exactly what the parser does from M1.2: it makes the identifier unique, records a
-     * {@link SpecificationIssue} saying so, and keeps both operations testable. What it may not do
-     * is hand over a model that cannot answer its own lookups.
+     * <p>Everything downstream looks an operation up by its identifier - per-operation settings,
+     * stored results, failure reports - and every one of them would silently get the wrong operation
+     * if two shared an identifier. RESTest's rule is to never let a bad specification crash the
+     * tool, so instead of rejecting the whole document, the parser makes the identifier unique,
+     * records a {@link SpecificationIssue} saying so, and keeps both operations testable. What it may
+     * not do is hand over a model that cannot answer its own lookups.
      */
     private static void rejectDuplicateIds(List<Operation> operations) {
         Map<OperationId, Operation> seen = new LinkedHashMap<>();

--- a/restest-core/src/main/java/io/restest/core/model/HeaderModel.java
+++ b/restest-core/src/main/java/io/restest/core/model/HeaderModel.java
@@ -20,11 +20,11 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * A header a response declares it will carry.
+ * A header that a response declares it will carry.
  *
- * <p>{@code required} is kept as well as the shape, because it is what the "missing required
- * header" oracle at M3.1 judges against: without it, a header the API promised and did not send is
- * indistinguishable from one it never promised.
+ * <p>{@code required} is kept alongside the header's shape because it is what makes it possible to
+ * check for a missing header later: without it, a header the API promised and failed to send would
+ * be indistinguishable from one it never promised at all.
  *
  * @param required whether the API states the header is always present
  * @param schema the shape of its value

--- a/restest-core/src/main/java/io/restest/core/model/HttpMethod.java
+++ b/restest-core/src/main/java/io/restest/core/model/HttpMethod.java
@@ -19,11 +19,12 @@ import java.util.Locale;
 import java.util.Optional;
 
 /**
- * The HTTP methods an operation can use.
+ * The HTTP methods (GET, POST, and so on) that an API operation can use.
  *
- * <p>The eight OpenAPI has always allowed, plus {@code QUERY}, which OpenAPI 3.2 adds for
- * safe requests that carry a body. The scope in {@code docs/DESIGN.md} covers every 3.x, so a 3.2
- * document using it must land somewhere rather than being skipped.
+ * <p>These are the eight methods OpenAPI has always allowed, plus {@code QUERY}, added by OpenAPI
+ * 3.2 for requests that carry a body without changing anything on the server. RESTest supports every
+ * version of OpenAPI 3.x, so an operation using {@code QUERY} must be represented too, rather than
+ * being skipped.
  */
 public enum HttpMethod {
     GET,

--- a/restest-core/src/main/java/io/restest/core/model/Operation.java
+++ b/restest-core/src/main/java/io/restest/core/model/Operation.java
@@ -113,10 +113,9 @@ public record Operation(
      * charitably rather than costing the operation - the same judgement as a path parameter the
      * document forgot to mark required.
      *
-     * <p>Path-level parameters, which OpenAPI lets a document declare once for every operation
-     * under a path, have to be merged into the operation before it is constructed. That is the
-     * parser's job from M1.2, and getting it wrong fails loudly here rather than producing requests
-     * with braces in them.
+     * <p>Path-level parameters, which OpenAPI lets a document declare once for every operation under
+     * a path, have to be merged into the operation before it is constructed. Getting that merge
+     * wrong fails loudly here rather than producing requests with unfilled braces in them.
      */
     private static void rejectUnfillableTemplate(String path, List<Parameter> parameters) {
         Set<String> declared = parameters.stream()
@@ -190,8 +189,8 @@ public record Operation(
      * oracle validate a 404 body against the shape declared for every other error, so the precedence
      * lives here rather than being left to each caller to remember.
      *
-     * <p>Empty when the document declares nothing that covers the code - itself a finding, and one
-     * the status-conformance oracle reports from M3.1.
+     * <p>Empty when the document declares nothing that covers the code - itself worth reporting,
+     * since it means the API answered in a way its own specification never described.
      */
     public Optional<ResponseModel> responseFor(int statusCode) {
         return firstDeclaring(String.valueOf(statusCode))

--- a/restest-core/src/main/java/io/restest/core/model/ParameterLocation.java
+++ b/restest-core/src/main/java/io/restest/core/model/ParameterLocation.java
@@ -24,8 +24,9 @@ package io.restest.core.model;
  *
  * <p>The older OpenAPI 2.0 format has two more locations, {@code body} and {@code formData}, and
  * they are deliberately absent here: a body is not treated as a parameter in this model, it is
- * {@link Operation#requestBody()}. Documents written in that older format are converted when they
- * are read, and it is worth writing down how, because only one of the two conversions is obvious:
+ * {@link Operation#requestBody()}. A document written in that older format must be converted into
+ * this shape when it is read, and it is worth writing down how, because only one of the two
+ * conversions is obvious:
  *
  * <ul>
  *   <li>{@code in: body} becomes a {@link RequestBodyModel} whose schema is the parameter's. The

--- a/restest-core/src/main/java/io/restest/core/model/ParameterLocation.java
+++ b/restest-core/src/main/java/io/restest/core/model/ParameterLocation.java
@@ -22,10 +22,10 @@ package io.restest.core.model;
  * with one of them: {@code id} in the query string and {@code id} in the path are two different
  * parameters, which is why {@link Operation#parameter(String, ParameterLocation)} asks for both.
  *
- * <p>OpenAPI 2.0 has two more, {@code body} and {@code formData}, and they are deliberately absent
- * here: a body is not a parameter in the 3.x shape this model follows, it is
- * {@link Operation#requestBody()}. Converting is the parser's job from M1.2, and it is worth
- * writing down because only one of the two conversions is obvious:
+ * <p>The older OpenAPI 2.0 format has two more locations, {@code body} and {@code formData}, and
+ * they are deliberately absent here: a body is not treated as a parameter in this model, it is
+ * {@link Operation#requestBody()}. Documents written in that older format are converted when they
+ * are read, and it is worth writing down how, because only one of the two conversions is obvious:
  *
  * <ul>
  *   <li>{@code in: body} becomes a {@link RequestBodyModel} whose schema is the parameter's. The

--- a/restest-core/src/main/java/io/restest/core/model/ParameterStyle.java
+++ b/restest-core/src/main/java/io/restest/core/model/ParameterStyle.java
@@ -20,10 +20,10 @@ import java.util.Objects;
 /**
  * How a parameter's value is written onto the wire.
  *
- * <p>It matters as soon as a value is not a single scalar: a list of tags in the query string is
- * {@code tags=a&tags=b} in one style and {@code tags=a,b} in another, and an API that documents one
- * will reject the other. The engine at M1.3 needs to be told which, so the model carries it rather
- * than guessing.
+ * <p>It matters as soon as a value is more than a single item: a list of tags in the query string is
+ * {@code tags=a&tags=b} in one style and {@code tags=a,b} in another, and an API documented for one
+ * will reject a request written in the other. RESTest needs to be told which style applies, so it is
+ * recorded here rather than guessed.
  *
  * <p>The names are OpenAPI's. Where a document says nothing, {@link #defaultFor} gives the default
  * the format defines.

--- a/restest-core/src/main/java/io/restest/core/model/ServerVariable.java
+++ b/restest-core/src/main/java/io/restest/core/model/ServerVariable.java
@@ -22,11 +22,10 @@ import java.util.Optional;
 /**
  * A variable in a server's URL template, and what the document says to put there.
  *
- * <p>OpenAPI requires a default for every server variable, which is what makes
- * {@link Server#resolvedUrl()} possible and design principle 1 - zero configuration to start -
- * keepable for an API whose only declared server is templated. Dropping the variables would leave
- * the tool unable to send a single request to such an API without {@code --url}, using a document
- * that said exactly where to send it.
+ * <p>OpenAPI requires every server variable to have a default value, which is what lets
+ * {@link Server#resolvedUrl()} build a working URL on its own. That, in turn, is what lets RESTest
+ * send a request straight away to an API whose base URL is templated, without asking the user to
+ * supply one first.
  *
  * @param defaultValue the value to use when nobody chooses another. Always present in a valid
  *     document

--- a/restest-core/src/main/java/io/restest/core/model/SpecificationIssue.java
+++ b/restest-core/src/main/java/io/restest/core/model/SpecificationIssue.java
@@ -19,21 +19,18 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Something in the document we could not use: where it was, what it cost, and which operation it
- * belongs to.
+ * Something in the API's specification document that RESTest could not fully use: where it was,
+ * what it cost, and which operation it belongs to.
  *
- * <p>Design principle 2 says the tool never crashes on a bad specification: it skips the offending
- * operation and reports it. This is the reporting half. Without it the skipping half is dishonest -
- * a run that silently tested 40 of an API's 60 operations looks exactly like a run of a
- * 40-operation API, and the user has no way to tell which they got.
+ * <p>A broken or unusual specification must never crash RESTest: instead, the affected operation is
+ * skipped and the problem is reported here. Without that report, a run that silently tested 40 of an
+ * API's 60 operations would look exactly like a run of a 40-operation API, leaving the user no way
+ * to tell which one they got.
  *
- * <p>{@link Effect} is what separates "this operation is not being tested at all" from "it is being
- * tested with less information than the document actually contains". M1.2 has to report both - a
- * malformed operation is skipped, an OpenAPI 3.2 construct we do not read yet only degrades what we
- * know - and a reader who cannot tell them apart cannot judge the run. The operation identifier is
- * carried for the same reason: a report that groups findings by operation should be able to show
- * "and here is what we could not read about this one" beside them, without parsing it back out of
- * a location string.
+ * <p>{@link Effect} tells apart "this operation is not being tested at all" from "it is being tested
+ * with less information than the document actually contains" - a reader who cannot tell those apart
+ * cannot properly judge the run. The operation identifier is kept for the same reason: a report that
+ * groups findings by operation can show what could not be read about each one, right next to it.
  *
  * @param location where in the document the problem is, written the way the document is navigated:
  *     {@code paths./pets.get.parameters[2]}. Precise enough to open the file and look

--- a/restest-core/src/main/java/io/restest/core/schema/ArraySchema.java
+++ b/restest-core/src/main/java/io/restest/core/schema/ArraySchema.java
@@ -21,9 +21,10 @@ import java.util.Optional;
 /**
  * An array of values that all share one shape.
  *
- * <p>Per-position shapes - JSON Schema's tuple form, {@code prefixItems} - are not represented.
- * A document using one parses to an {@link UnsupportedSchema} from M1.2, which says so, rather than
- * being silently read as an array of the first element's shape.
+ * <p>Arrays whose elements each have their own, different declared shape (JSON Schema's tuple form,
+ * {@code prefixItems}) are not represented here. A document using that is read as an
+ * {@link UnsupportedSchema}, which says so, rather than being silently misread as an array of just
+ * the first element's shape.
  *
  * @param metadata the type-independent facts
  * @param items the shape every element has

--- a/restest-core/src/main/java/io/restest/core/schema/ArraySchema.java
+++ b/restest-core/src/main/java/io/restest/core/schema/ArraySchema.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  * An array of values that all share one shape.
  *
  * <p>Arrays whose elements each have their own, different declared shape (JSON Schema's tuple form,
- * {@code prefixItems}) are not represented here. A document using that is read as an
+ * {@code prefixItems}) are not represented here. A document using that is meant to be read as an
  * {@link UnsupportedSchema}, which says so, rather than being silently misread as an array of just
  * the first element's shape.
  *

--- a/restest-core/src/main/java/io/restest/core/schema/CanonicalSchema.java
+++ b/restest-core/src/main/java/io/restest/core/schema/CanonicalSchema.java
@@ -16,16 +16,19 @@
 package io.restest.core.schema;
 
 /**
- * The shape of a value: what an API says it will accept or return, in types we own.
+ * The shape of a value: what an API says a field, a parameter or a whole request or response body
+ * is allowed to look like.
  *
- * <p>A specification describes shapes in JSON Schema, whose vocabulary is far wider than a black-box
- * tester can act on and whose spelling differs between OpenAPI 2.0, 3.0 and 3.1. Everything after
- * the parser - generating a value, judging a response, explaining a failure - works against this
- * hierarchy instead, so those differences are dealt with once, in {@code restest-spec}, and nowhere
- * else.
+ * <p>An API's specification describes these shapes using JSON Schema, a much richer notation than a
+ * tool that only sends requests and checks responses actually needs, and one whose exact spelling
+ * differs across OpenAPI versions. Everything in RESTest that comes after reading the specification -
+ * choosing what value to send, checking whether a response matches, explaining a failure - works
+ * against this simpler set of ten shapes instead, so those version differences only ever have to be
+ * dealt with once, in the part of RESTest that reads the specification, and nowhere else.
  *
- * <p>Sealed, so that a generator or an oracle that handles nine of the ten cases fails to
- * compile rather than falling through to a default and quietly producing nothing:
+ * <p>There are exactly ten kinds of shape, which the compiler enforces: code that is meant to handle
+ * every kind must actually handle all ten, rather than falling through to a default and quietly
+ * doing nothing useful for the one it missed:
  *
  * {@snippet :
  * Object value = switch (schema) {
@@ -42,14 +45,14 @@ package io.restest.core.schema;
  * };
  * }
  *
- * <p>Three of those cases are worth separating. {@link AnySchema} is a schema that declares no type -
- * legal, common, and meaning "any value will do". {@link UnsupportedSchema} is a shape we could not
- * represent: a composition we do not read until M2.1, a reference that does not resolve, a
- * construct from a version of the format we have not caught up with. Design principle 2 says a bad
- * specification must never crash the tool, and this is where that principle lands in the data: the
- * problem is carried, with its reason, instead of being thrown or silently flattened into
- * "anything". {@link NothingSchema} is the third: the document was understood and what it said is
- * that no value is acceptable.
+ * <p>Three of those ten are worth calling out. {@link AnySchema} is a schema that declares no type at
+ * all - legal, common, and meaning "any value will do". {@link UnsupportedSchema} is a shape RESTest
+ * could not represent: a combination of shapes it does not yet understand, a reference that does not
+ * resolve, a construct from a newer version of the format. RESTest's rule is that a badly written or
+ * unusual specification must never crash the tool, and this is that rule applied to data: the
+ * problem is recorded, with its reason, instead of stopping the run or silently pretending "anything
+ * goes". {@link NothingSchema} is the third: the document was understood perfectly, and what it said
+ * is that no value at all is acceptable.
  *
  * <p>Every implementation is an immutable record whose first component is its {@link SchemaMetadata}
  * - the facts JSON Schema attaches to a value regardless of its type.

--- a/restest-core/src/main/java/io/restest/core/schema/NullSchema.java
+++ b/restest-core/src/main/java/io/restest/core/schema/NullSchema.java
@@ -23,7 +23,7 @@ import java.util.Objects;
  *
  * <p>Distinct from a nullable schema. {@code SchemaMetadata.nullable()} says "this string may also
  * be null"; this says "null is the only accepted value", which is rare but real - most often one
- * arm of a composition that M2.1 will fold in.
+ * option among several possible shapes a document offers for the same value.
  */
 public record NullSchema(SchemaMetadata metadata) implements CanonicalSchema {
 

--- a/restest-core/src/main/java/io/restest/core/schema/NumberSchema.java
+++ b/restest-core/src/main/java/io/restest/core/schema/NumberSchema.java
@@ -22,17 +22,17 @@ import java.util.Optional;
 /**
  * A number, whole or not, with the bounds the document states.
  *
- * <p>{@link BigDecimal} rather than {@code double} throughout: a bound is a fact the API will
- * enforce exactly, and the whole point of M2.3's boundary walk is to send precisely the documented
- * limit and precisely one step past it. Rounding the limit on the way in would make that test a
+ * <p>{@link BigDecimal} is used instead of {@code double} throughout: a bound is a fact the API will
+ * enforce exactly, and one useful way RESTest tests that is by sending precisely the documented limit
+ * and precisely one step past it. Rounding the limit on the way in would turn that check into a
  * guess.
  *
- * <p>The exclusive bounds are numbers, not flags, which is the JSON Schema 2020-12 and OpenAPI 3.1
- * shape and the one that loses nothing. OpenAPI 3.0 writes the same fact as {@code minimum: 5}
- * alongside {@code exclusiveMinimum: true}, and the parser converts: the value moves to
- * {@link #exclusiveMinimum()} and {@link #minimum()} is left empty. Modelled the other way round -
- * a {@code minimum} plus a boolean - a 3.1 document writing {@code exclusiveMinimum: 5} with no
- * {@code minimum} has nowhere to put the number, and the bound is silently lost.
+ * <p>The exclusive bounds ("must be strictly less/greater than") are stored as numbers, not as a flag
+ * next to a plain bound, since that is the shape that loses no information across OpenAPI versions:
+ * an older document writing {@code minimum: 5} alongside {@code exclusiveMinimum: true} is converted
+ * on reading so that the value moves to {@link #exclusiveMinimum()} and {@link #minimum()} is left
+ * empty, and a newer document writing {@code exclusiveMinimum: 5} directly has a natural place to put
+ * it too.
  *
  * @param metadata the type-independent facts
  * @param kind whether the value must be whole
@@ -88,11 +88,10 @@ public record NumberSchema(
 
     /*
      * There is deliberately no lowerBound()/upperBound() pair collapsing the four components into
-     * two. A bound without its strictness is the wrong answer to every question worth asking:
-     * M2.3's boundary walk sends precisely the documented limit and precisely one step past it, and
-     * whether the limit itself is accepted is the whole difference between the two. Collapsing also
-     * has to decide what a document stating both an inclusive and an exclusive bound means, which
-     * JSON Schema answers (the tighter wins) and a convenience accessor would get wrong quietly.
-     * Whatever M2.3 needs, it can introduce with the strictness attached.
+     * two. A bound without knowing whether it is inclusive or exclusive is the wrong answer to every
+     * question worth asking here, since whether the limit itself is accepted is the whole difference
+     * between the two. Collapsing them would also have to decide what a document stating both an
+     * inclusive and an exclusive bound means, which JSON Schema already answers (the tighter one
+     * wins) and a convenience accessor could easily get wrong.
      */
 }

--- a/restest-core/src/main/java/io/restest/core/schema/SchemaChecks.java
+++ b/restest-core/src/main/java/io/restest/core/schema/SchemaChecks.java
@@ -33,9 +33,10 @@ import java.util.Optional;
  * actually satisfies either; working that out needs a more thorough check elsewhere. The promise
  * here is only that the bounds a simple comparison can catch do not contradict each other.
  *
- * <p>Rejecting a contradiction here does not make the whole specification unusable. RESTest never
- * crashes on a bad specification: the part of RESTest that reads the document catches this rejection,
- * records it as an issue, skips just the affected operation, and reads the next one.
+ * <p>Rejecting a contradiction here does not make the whole specification unusable. RESTest's rule
+ * is to never crash on a bad specification: whatever reads the document is meant to catch this
+ * rejection, record it as an issue, skip just the affected operation, and read the next one - not to
+ * let one bad operation bring the whole run down.
  */
 final class SchemaChecks {
 

--- a/restest-core/src/main/java/io/restest/core/schema/SchemaChecks.java
+++ b/restest-core/src/main/java/io/restest/core/schema/SchemaChecks.java
@@ -27,18 +27,15 @@ import java.util.Optional;
  * {@code minItems: -1} describes nothing at all. Letting either through would mean every generator
  * and every oracle downstream re-discovering the contradiction, or worse, not noticing it.
  *
- * <p>This is not a satisfiability check, and nothing downstream should treat it as one.
- * {@code type: integer, minimum: 1.2, maximum: 1.8} and {@code minimum: 10, maximum: 19,
- * multipleOf: 100} are both accepted here and satisfied by no value; deciding those needs the
- * solver, which arrives at M5.2, not a constructor. The promise is only that the bounds a
- * constructor can compare do not contradict each other.
+ * <p>This is not a full check of whether any value could ever satisfy the bounds, and nothing
+ * downstream should treat it as one. {@code type: integer, minimum: 1.2, maximum: 1.8} and
+ * {@code minimum: 10, maximum: 19, multipleOf: 100} are both accepted here even though no value
+ * actually satisfies either; working that out needs a more thorough check elsewhere. The promise
+ * here is only that the bounds a simple comparison can catch do not contradict each other.
  *
- * <p>What is rejected does not make a specification fatal. Design principle 2 requires the tool to
- * carry on, and the division of labour is that the model throws and the parser catches: from M1.2,
- * {@code restest-spec} turns the exception into a
- * {@link io.restest.core.model.SpecificationIssue}, skips the operation, and reads the next one.
- * The alternative - a model that accepts nonsense so that nothing has to catch anything - only
- * moves the failure to somewhere with less context to report it.
+ * <p>Rejecting a contradiction here does not make the whole specification unusable. RESTest never
+ * crashes on a bad specification: the part of RESTest that reads the document catches this rejection,
+ * records it as an issue, skips just the affected operation, and reads the next one.
  */
 final class SchemaChecks {
 

--- a/restest-core/src/main/java/io/restest/core/schema/SchemaMetadata.java
+++ b/restest-core/src/main/java/io/restest/core/schema/SchemaMetadata.java
@@ -48,8 +48,8 @@ public record SchemaMetadata(
      * Which direction a value may travel.
      *
      * <p>One enum rather than the two booleans OpenAPI uses, because {@code readOnly} and
-     * {@code writeOnly} being true at once is a contradiction the type should not be able to
-     * express. It matters from M2.5: a property the API only ever returns must not be sent in a
+     * {@code writeOnly} being true at once is a contradiction this type should not be able to
+     * express. It matters because a property the API only ever returns must not be sent in a
      * request body, and one it only ever accepts must not be expected in a response.
      */
     public enum Access {

--- a/restest-core/src/main/java/io/restest/core/schema/SchemaReference.java
+++ b/restest-core/src/main/java/io/restest/core/schema/SchemaReference.java
@@ -27,10 +27,10 @@ import java.util.Objects;
  * to some arbitrary depth and describe a shape the document does not, or declare a construct
  * unsupported that the tool could in fact test.
  *
- * <p>Referring by name also keeps the name, which is thrown away by inlining and wanted later: the
- * operation dependency graph at M4.1 infers relationships from names as well as types, a value
- * dictionary at M6.1 is keyed on them, and {@code restest explain} reads better saying "a Pet" than
- * repeating a shape.
+ * <p>Referring by name also keeps the name itself, which would otherwise be thrown away, and the
+ * name is useful later: it helps relate one part of the API to another, it can be used to look up a
+ * value someone has prepared specifically for that named shape, and an explanation of a test reads
+ * better saying "a Pet" than repeating the whole shape.
  *
  * <p>Resolution is {@link io.restest.core.model.ApiModel#schema(String)}, which holds the named
  * schemas the document declared. A reference whose name the document never declares resolves to

--- a/restest-core/src/main/java/io/restest/core/schema/StringSchema.java
+++ b/restest-core/src/main/java/io/restest/core/schema/StringSchema.java
@@ -25,12 +25,12 @@ import java.util.Optional;
  * @param minLength the shortest accepted string
  * @param maxLength the longest
  * @param pattern the regular expression an accepted string must match, exactly as the document
- *     wrote it. It is not compiled here: JSON Schema's dialect is ECMA-262 and Java's is not, so
- *     translating it is the generator's job at M2.4, and compiling it here would reject patterns
- *     that are valid in the format we are reading
+ *     wrote it. It is not compiled here: JSON Schema's regular-expression dialect is not quite the
+ *     same as Java's, so translating it is left to the code that generates values, and compiling it
+ *     here could reject patterns that are perfectly valid in the format being read
  * @param format the format name - {@code date-time}, {@code email}, {@code uuid} and the rest -
- *     kept as a string because the list is open: a document may use a name nobody has standardised,
- *     and an enum would lose it. Format-aware generation arrives at M2.4
+ *     kept as a plain string rather than a fixed list, since a document may use a name nobody has
+ *     standardised and a fixed list would lose it
  */
 public record StringSchema(
         SchemaMetadata metadata,

--- a/restest-core/src/main/java/io/restest/core/schema/UnsupportedSchema.java
+++ b/restest-core/src/main/java/io/restest/core/schema/UnsupportedSchema.java
@@ -18,21 +18,23 @@ package io.restest.core.schema;
 import java.util.Objects;
 
 /**
- * A shape the tool could not represent, carrying why.
+ * A shape that RESTest could not represent, together with why.
  *
- * <p>This is design principle 2 - never crash on a bad specification - expressed in the data.
- * Something will always be unreadable: a composition we do not fold in until M2.1, a reference that
- * does not resolve, a keyword from a version of the format newer than our parser. The three ways of
- * dealing with that are to throw, to pretend the schema said nothing, or to record the gap. Only the
- * third lets the run continue and still tells the truth afterwards.
+ * <p>RESTest's rule is to never crash on a badly written or unusual specification, and this is that
+ * rule applied to data. Something will always be unreadable: a combination of shapes not yet
+ * understood, a reference that does not resolve, a keyword from a newer version of the format than
+ * RESTest supports. The alternatives to recording the gap here would be to stop the run entirely, or
+ * to silently pretend the schema said nothing - and only recording the gap lets the run continue
+ * while still telling the truth about what happened.
  *
- * <p>So a generator meeting one knows it is working blind and can weight its guesses accordingly, an
- * oracle knows not to report a mismatch it cannot judge, and {@code restest explain} can name the
- * construct that defeated us instead of showing a blank.
+ * <p>That way, whatever generates values knows it is working blind here and can be more cautious,
+ * whatever checks a response knows not to report a mismatch it cannot actually judge, and a later
+ * explanation of the run can name the exact construct that defeated it instead of showing a blank.
  *
  * @param metadata whatever type-independent facts survived - often a description and nothing else
- * @param reason what could not be represented, in a form fit to print in a report: "oneOf with 3
- *     alternatives is not folded in until M2.1", not "unsupported"
+ * @param reason what could not be represented, in a form fit to print in a report, such as
+ *     "a value declared as one of several alternative shapes is not supported yet" - not merely
+ *     "unsupported"
  */
 public record UnsupportedSchema(SchemaMetadata metadata, String reason) implements CanonicalSchema {
 

--- a/restest-core/src/main/java/module-info.java
+++ b/restest-core/src/main/java/module-info.java
@@ -24,9 +24,10 @@
  * helpers shared between the other four and is deliberately kept internal, so it can change freely
  * without affecting anything built on top of this module.
  *
- * <p>This module depends on nothing else in RESTest: it defines the vocabulary that the parser, the
- * test generator, the HTTP engine and the reporting code all share, without needing any of them
- * itself.
+ * <p>The module requires nothing: no parser, no HTTP client, no constraint solver, no database
+ * driver. It defines the vocabulary that the parser, the test generator, the HTTP engine and the
+ * reporting code all share, without needing any of them itself - so depending on this module never
+ * pulls in anything heavier than this module itself.
  */
 module io.restest.core {
     exports io.restest.core.execution;

--- a/restest-core/src/main/java/module-info.java
+++ b/restest-core/src/main/java/module-info.java
@@ -15,15 +15,18 @@
  */
 
 /**
- * The domain model: what an API is, in types we own.
+ * This is the module that describes, in plain data, what a REST API and a test against it look
+ * like: the operations an API offers, the requests and responses of one test attempt, and the
+ * shapes ({@code schema}) that data must follow. Every other part of RESTest is built on top of
+ * these definitions.
  *
- * <p>Four packages are exported and one is not. {@code io.restest.core.internal} holds plumbing
- * shared between the other four and is deliberately kept internal, so that it can change without
- * changing anything a consumer compiled against.
+ * <p>Four packages are exported and one is not. {@code io.restest.core.internal} holds small
+ * helpers shared between the other four and is deliberately kept internal, so it can change freely
+ * without affecting anything built on top of this module.
  *
- * <p>The module requires nothing. That is the point of ADR-0004: a consumer depending on
- * {@code restest-core} takes on the model and no parser, no HTTP client, no solver and no database
- * driver.
+ * <p>This module depends on nothing else in RESTest: it defines the vocabulary that the parser, the
+ * test generator, the HTTP engine and the reporting code all share, without needing any of them
+ * itself.
  */
 module io.restest.core {
     exports io.restest.core.execution;


### PR DESCRIPTION
**Increment:** none — a documentation-only cleanup requested directly by the maintainer, not a numbered item from `ROADMAP.md`.

## What you can do now that you could not before

Nothing about running RESTest changes. What changes is who can read `restest-core`'s Javadoc and get something out of it: it no longer assumes the reader has `ROADMAP.md`, the ADRs or `docs/DESIGN.md` open next to the code, and every class-level comment now says, in plain language, what the class is for when testing a REST API.

## Try it yourself

    git fetch && git switch docs/javadoc-self-contained-comments
    ./mvnw -q -pl restest-core javadoc:javadoc
    open restest-core/target/reports/apidocs/index.html

    Expected: the API docs build with zero errors, and every page reads without needing to know what
    "M1.3" or "ADR-0006" mean.

## How it works

Javadoc comments (`/** ... */`) across `restest-core` and `restest-arch-tests` used to cite `ADR-XXXX`, `ROADMAP.md`, `docs/DESIGN.md` and milestone codes like `M1.3` or `M4.2` — shorthand that only makes sense to someone following this project's own planning process. Those references are removed; a Javadoc comment may now only point at other code (via `@link`). Where a milestone code used to mark something as *not built yet*, the sentence is now written to say so plainly, in its own words, instead of asserting the behaviour as if it already existed.

The rest of the language is simplified throughout, and every class-level comment is rewritten to explain, without jargon, what the class represents when testing a REST API and how it relates to the classes around it.

`CLAUDE.md` gains a short "Javadoc comments" section recording these three rules for future work, so this style keeps applying without being re-explained each time.

## What changed in the code

Comment-only change across 37 files in `restest-core/src/main` and `restest-arch-tests/src/test`, plus `CLAUDE.md`. No production code, method signature, or test assertion was touched — verified by diffing each file with comments stripped out before and after.

Two rounds went into this: a first pass removed every internal-doc reference, and an independent review (the `reviewer` subagent) then caught that trimming milestone codes had silently changed tense in a few places — turning "not built yet" into "this is what happens" — and that two rewrites had dropped real technical warnings rather than just jargon (`ValueOrigin.Derived`'s ordering caveat, and `ArchitectureRules`'s escape hatch for a genuine root-level class). A second commit fixes those.

## Evidence

- [x] Tests: unchanged, all green — `./mvnw -pl restest-core,restest-arch-tests -am test`
- [x] Architecture tests: unchanged — none weakened
- [ ] Mutation score (if oracles or constraints were touched): not applicable, no oracle/constraint code touched
- [ ] Per-request overhead: not applicable
- [ ] Smoke run, two containerised APIs: not applicable, no execution-path code touched
- [ ] Idle time: not applicable
- [x] Artefact: `./mvnw -pl restest-core javadoc:javadoc` builds with 0 errors

## Decisions taken

- Plain `//`/`/* */` comments and string literals (`@DisplayName`, ArchUnit's `.as(...)` rule descriptions) were left untouched. The request was specifically about Javadoc; those strings serve a different purpose (test-report labels, rule descriptions) and rewriting them was out of scope.
- This isn't a `ROADMAP.md` increment, so it doesn't have a milestone number or a `feat/<milestone>-<n>-<slug>` branch name; I used `docs/<slug>` instead. Happy to rename if a different convention is preferred for non-increment work.
- The original branch for the M1.1b increment this Javadoc belonged to (`feat/m1-1b-execution-model`) was already squash-merged into `v2` as #285 before this request came in, so this is a fresh branch off current `v2` rather than more commits on that closed branch.

## Open questions

None.

---

- [x] Targets `v2`, not `main`
- [x] English throughout, including comments and test names
- [x] Nothing from the deferred backlog ("Out of scope for v2.0" in `docs/DESIGN.md`)
- [x] No AI abstraction; no benchmark-platform reference under `src/`
- [x] Reviewed by the `reviewer` subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)