### PR TITLE
Move input-generation groundwork into M2, defer failure clustering

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # RESTest 2.0 — roadmap
 
-44 increments in 9 milestones. One increment = one branch = one pull request into `v2`.
+43 increments in 9 milestones. One increment = one branch = one pull request into `v2`.
 Take them in order unless told otherwise. Design rationale in `docs/DESIGN.md`.
 
 **Supervision points** are marked 🛑. At those, stop and wait for review rather than continuing.
@@ -60,6 +60,12 @@ other coupling to that infrastructure is implied or intended (ADR-0011 still hol
 | 2.4 | Format-aware and pattern-based generators (date, e-mail, UUID, regular expressions) | Values real APIs accept |
 | 2.5 | Request bodies: JSON, form encoding, multipart, XML | Write operations become testable |
 | 2.6 | Authentication inferred from `securitySchemes` (API key, bearer, basic, OAuth2 client credentials) | Protected APIs stop returning 401 for everything |
+| 2.7 | Value dictionary format, reader, writer, disk cache | Good values computed once, reused for ever, committed next to the specification |
+| 2.8 | `ExternalDataProvider` interface: file-based implementation + out-of-process transport, asynchronous, never blocking | Any program in any language can suggest input values without slowing the run |
+
+2.8's own "never blocking" guarantee is proved at that increment, by its own test (a slow provider
+must not stall the run) — not by waiting for M6.2's overhead regression test, which lands much later
+and checks the tool's overall per-request overhead, not any one extension point.
 
 ## M3 — Oracles, faults and reporting
 
@@ -69,8 +75,11 @@ other coupling to that infrastructure is implied or intended (ADR-0011 still hol
 | 3.2 | HTTP-semantics and REST-design oracles (WFC 900–909 and 950–965) | Protocol-level bugs nobody else on our side detects |
 | 3.3 | `CorpusOracle` interface and `restest recheck <run>` | Re-examine a finished run with new oracles, offline, no API calls |
 | 3.4 | Per-operation oracle configuration + published JSON Schema for the config file | False positives silenced per operation instead of the tool being switched off |
-| 3.5 | Failure deduplication and clustering | 4,000 failures become 12 distinct problems |
-| 3.6 | Reports: HTML, JUnit XML, HAR, NDJSON; JUnit 5 + REST-Assured code export; `restest explain`; `restest replay`. Plus the "how to add an oracle, a provider, a report" guide | Results usable in CI, in an IDE, and by a human |
+| 3.5 | Reports: HTML, JUnit XML, HAR, NDJSON; JUnit 5 + REST-Assured code export; `restest explain`; `restest replay`. Plus the "how to add an oracle, a provider, a report" guide | Results usable in CI, in an IDE, and by a human |
+
+v2.0's own reports are raw: one finding per operation, not grouped. Deduplication and clustering is
+deferred (see below), not a gap in 3.5 — a milestone campaign's cross-tool comparison is RESTGym's
+job, not this report's.
 
 ## M4 — Stateful testing
 
@@ -93,14 +102,12 @@ other coupling to that infrastructure is implied or intended (ADR-0011 still hol
 | 5.4 | Constraint-based generator: valid requests and deliberate dependency violations | RESTest's differentiator, back and usable |
 | 5.5 | 🛑 Constraint-aware oracles (`2XX_P`, `2XX_D`, `4XX`) + the ICSOC'20 experiment re-run | The two novel oracles work, and we can compare against the published 1.x numbers |
 
-## M6 — External data and live model updates
+## M6 — Live updates and performance
 
 | # | Increment | What it enables |
 |---|---|---|
-| 6.1 | Value dictionary format, reader, writer, disk cache | Good values computed once, reused for ever, committed next to the specification |
-| 6.2 | `ExternalDataProvider` interface: file-based implementation + out-of-process transport, asynchronous, never blocking | Any program in any language can suggest input values without slowing the run |
-| 6.3 | `ConstraintSource` and `FlowSource` with a watched-directory implementation | Drop an IDL snippet in mid-run and watch the generated requests change |
-| 6.4 | 🛑 Idle-time reporting and the per-request overhead regression test wired into CI | We can prove the 2026 failure mode cannot recur |
+| 6.1 | `ConstraintSource` and `FlowSource` with a watched-directory implementation | Drop an IDL snippet in mid-run and watch the generated requests change |
+| 6.2 | 🛑 Idle-time reporting and the per-request overhead regression test wired into CI | We can prove the 2026 failure mode cannot recur |
 
 ## M7 — Packaging and distribution
 
@@ -132,6 +139,7 @@ so none of them requires re-architecting. Full table under "Out of scope for v2.
 - Semantic oracles inferred from request/response corpora → corpus oracles + store + `recheck`
 - Semantic oracles inferred from the specification → corpus oracles
 - Metamorphic relations → corpus oracles
+- Failure deduplication and clustering → interaction store + an event-stream listener
 - Predicting whether a request will be accepted before sending it → feedback
 - Search-based or reinforcement-learning scheduling → feedback
 - Surrogate coverage goals for black-box search → feedback

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -294,6 +294,7 @@ re-architecting — which is the point of listing them at all.
 | **Semantic oracles inferred from request/response corpora** | `CorpusOracle` + store + offline re-check |
 | Semantic oracles inferred from the specification | `CorpusOracle` |
 | Metamorphic relations | `CorpusOracle` |
+| Failure deduplication and clustering | Interaction store + an event-stream listener |
 | Predicting whether a request will be accepted before sending it | `FeedbackListener` |
 | Search-based or reinforcement-learning scheduling | `FeedbackListener` |
 | Surrogate coverage goals for black-box search | `FeedbackListener` |

--- a/docs/adr/0005-interpreted-test-model.md
+++ b/docs/adr/0005-interpreted-test-model.md
@@ -155,7 +155,7 @@ instead.
 Not represented, deliberately: a `TestCase` the engine planned but never attempted - shed by adaptive
 concurrency, cut off by the budget. No request went out, so no `Interaction` exists for it; inventing
 one would mean fabricating `sentAt`. Counting "planned versus attempted" stays the engine's and the
-report's job (M1.3, M3.6).
+report's job (M1.3, M3.5).
 
 **`Payload` gained `wireLength`**, replacing an earlier `truncated` boolean, after review. ADR-0006
 names "configurable response-body truncation" as the store's answer to storage cost, so a stored
@@ -208,7 +208,7 @@ is exactly where an `Authorization` bearer token or an API key (M2.6) travels, a
 generated `toString` would print it verbatim into any log line or report. Both override `toString` to
 show header *names* only, plus the body's own already-safe summary. This does not solve secret
 redaction in general - a credential in a query string or inside a body is not caught by it - which is
-left to the reporting work in M3.6; it closes the one leak this increment could close cheaply.
+left to the reporting work in M3.5; it closes the one leak this increment could close cheaply.
 
 `HttpResponseRecord` also gained the reason phrase and protocol version, both optional, as part of
 its `StatusLine` (see above) rather than as fields of its own: M3.2's HTTP-semantics oracles want

--- a/docs/adr/0012-canonical-model.md
+++ b/docs/adr/0012-canonical-model.md
@@ -62,7 +62,7 @@ into every report.
 `ApiModel.schemas()` holds. This is what makes a *recursive* shape representable at all — held by
 value, a comment with replies or a category with sub-categories would have to contain itself — and it
 is what keeps the name, which inlining destroys and which the operation dependency graph at M4.1, the
-value dictionary at M6.1 and `restest explain` all want back. Resolution is explicit and one step
+value dictionary at M2.7 and `restest explain` all want back. Resolution is explicit and one step
 deep: a document may point one name at another, and a model that followed chains silently would loop
 for ever on one that points at itself.
 

--- a/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRulesSelfTest.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRulesSelfTest.java
@@ -96,7 +96,7 @@ class ArchitectureRulesSelfTest {
                 "ExecTerminatingByProcessHandle");
 
         // Identical bytecode to the line above, but on a child process, which is legitimate and
-        // which M6.2's out-of-process transport will need. Flagging it would fail correct code.
+        // which M2.8's out-of-process transport will need. Flagging it would fail correct code.
         assertThatThrownBy(() -> ArchitectureRules
                 .onlyOneModuleMayTerminateTheProcess(MIRROR, "cli").check(mirrorClasses))
                 .describedAs("reaping a child process must not be reported; only a handle on this "


### PR DESCRIPTION
**Increment:** roadmap restructuring (no numbered increment; project-planning change directed by the maintainer)

## What you can do now that you could not before

Nothing — this changes the plan of record only (`ROADMAP.md` and the two ADR/test cross-references
it touches), not the tool. It's here so the next several increments are taken in the order the
maintainer actually wants, and so nobody starts building 3.5 (failure clustering) before it's decided
whether that's still in scope.

## Try it yourself

    git fetch && git switch chore/roadmap-m2-m3-m6-restructure
    grep -c '^| [0-9]' ROADMAP.md

Expected:

    43

    ./mvnw -q verify

Expected: no output, exit code 0 (nothing here touches production code or tests in a way that
changes behaviour — see "What changed in the code").

## How it works

Three changes to the roadmap, requested by the maintainer, each checked against the ADRs before being
applied rather than just typed into the table.

**6.1 and 6.2 move from M6 into M2, as 2.7 and 2.8.** Both are about input generation — a dictionary
of good values, and a way for an external program to suggest values — which is exactly what M2
("Specification fidelity and input generation") is for; they had been filed under M6 only because
that's where "external data" as a category landed. M6's other two increments renumber down to 6.1 and
6.2, and the milestone is retitled from "External data and live model updates" to "Live updates and
performance", since "external data" no longer describes anything left in it.

**3.5 (failure deduplication and clustering) is deferred**, moved out of M3 into the "Deferred — not
in v2.0" list, with a matching row added to `docs/DESIGN.md`'s out-of-scope table. Nothing else in the
roadmap needs it to exist. **3.2 and 3.3 were checked for the same treatment and deliberately kept.**
ADR-0005 — the execution/interaction model already merged into `restest-core` — was written with
specific fields (the precise HTTP status line, a confirmed delivered `Content-Length`, the distinction
between what our own store truncated and what the API actually failed to deliver) whose sole stated
reason for existing, in the ADR's own text, is to serve 3.2's HTTP-semantics oracles and 3.3's
`restest recheck`. Deferring either would strand real, already-shipped design work with no near-term
reason to exist. This was flagged to the maintainer directly, with the ADR passages quoted, before
deciding to keep them.

Every place that named a renumbered increment by its old code was found and fixed: two spots in
ADR-0005, one in ADR-0012, and one `//` comment in an architecture-test file (that last one isn't
Javadoc, so it wasn't in violation of `CLAUDE.md`'s Javadoc rule, but it would have gone stale
otherwise).

## What changed in the code

- `ROADMAP.md` — the table changes above, plus two short clarifying notes a review pass asked for:
  one making explicit that 2.8's "never blocking" guarantee is proved by its own test, not by waiting
  for the later, system-wide overhead regression test (now 6.2); the other stating plainly that
  v2.0's own reports are raw, undeduplicated findings — deferring 3.5 doesn't quietly break the "a
  fault count is only meaningful next to somebody else's" claim in `docs/DESIGN.md`, because cross-tool
  comparison already runs through RESTGym, not this report.
- `docs/DESIGN.md` — mirrors the new deferred entry, phrased as "interaction store + an event-stream
  listener" (matching ADR-0006's own language — "independent subscribers" of the event stream — rather
  than a phrase that doesn't correspond to anything documented, which a review pass caught in an
  earlier draft).
- `docs/adr/0005-interpreted-test-model.md`, `docs/adr/0012-canonical-model.md` — two and one
  milestone-code pointer fixes respectively (`M3.6`→`M3.5`, `M6.1`→`M2.7`). No decision in either ADR
  changed; only the label for an increment that was already being pointed at.
- `restest-arch-tests/.../ArchitectureRulesSelfTest.java` — one comment fixed (`M6.2`→`M2.8`).

No production code, no test assertions, no architecture rules changed.

## Evidence

- [x] Tests: unchanged (this branch touches no test assertions); `./mvnw verify` still exits 0.
- [x] Architecture tests: unchanged, all still passing.
- [ ] Mutation score: n/a.
- [ ] Per-request overhead: n/a.
- [ ] Smoke run: n/a.
- [ ] Idle time: n/a.
- [x] Artefact: the diff to `ROADMAP.md` itself.

## Decisions taken

- **Kept 3.2 and 3.3 in place, against the original request, after finding they're load-bearing.**
  Covered above and asked back to the maintainer before proceeding — they confirmed keeping both.
- **Advancing 2.7/2.8 ahead of the rest of M3, M4 and M5 has a real sequencing consequence, not just a
  grouping one:** `ROADMAP.md` says increments are taken in order, so this also moves the
  `ExternalDataProvider` out-of-process transport (2.8) well ahead of the CI overhead regression test
  that would catch it if its "never blocking" guarantee regressed. Rather than reordering further to
  close that gap (which the maintainer did not ask for), a note was added to `ROADMAP.md` making the
  gap explicit and pointing at the mitigation: 2.8's own test proves its own guarantee; the later
  regression test is a second, broader net, not the first one.
- **Did not add an ADR amendment for the two pointer fixes.** ADR-0001 says decisions are recorded as
  immutable records and a reversed decision gets an amendment; a stale milestone-number label inside
  an ADR's prose is neither — no decision changed, only which number an already-referenced increment
  now has. Recorded here instead, in the PR that caused it, rather than inside the ADR files.
- **Did not rename increments to be cited by name instead of number** across the ADRs (a review pass
  suggested this as a way to make ADR prose immune to future renumbering). Worth doing at some point,
  but a repo-wide change to how every ADR cites the roadmap is a bigger, separate decision, not
  something to fold into a roadmap reshuffle.
- **Spun off, not fixed here:** `docs/adr/0001-record-architecture-decisions.md` still says "eleven
  short files" where there are now twelve — a pre-existing stale count unrelated to this change,
  flagged as a separate follow-up.

## Open questions

None.

---

- [x] Targets `v2`, not `main`
- [x] English throughout, including comments and test names
- [x] Nothing from the deferred backlog ("Out of scope for v2.0" in `docs/DESIGN.md`)
- [x] No AI abstraction; no benchmark-platform reference under `src/`
- [x] Reviewed by the `reviewer` subagent
