### PR TITLE
Point the tool at a real specification without it crashing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
         <assertj.version>3.27.7</assertj.version>
         <archunit.version>1.5.0</archunit.version>
         <jacoco.version>0.8.15</jacoco.version>
+        <swagger-parser.version>2.1.47</swagger-parser.version>
+        <!-- Arrives transitively through swagger-parser; pinned in its own right so a future
+             swagger-parser upgrade that changes it is a visible, reviewed version bump rather than
+             whatever Maven's dependency mediation happens to resolve (ADR-0007's own complaint about
+             RESTest 1.x's undeclared swagger-parser dependency, repeated one level down). -->
+        <snakeyaml.version>2.6</snakeyaml.version>
     </properties>
 
     <dependencyManagement>
@@ -90,6 +96,16 @@
                 <groupId>com.tngtech.archunit</groupId>
                 <artifactId>archunit-junit5</artifactId>
                 <version>${archunit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.parser.v3</groupId>
+                <artifactId>swagger-parser</artifactId>
+                <version>${swagger-parser.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/restest-core/src/main/java/io/restest/core/spec/SpecificationParser.java
+++ b/restest-core/src/main/java/io/restest/core/spec/SpecificationParser.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.core.spec;
+
+import io.restest.core.model.ApiModel;
+
+/**
+ * Reads an API's specification document and turns it into an {@link ApiModel}.
+ *
+ * <p>This is the only door into RESTest for an OpenAPI document. Everything on the other side of it
+ * - test generation, execution, reporting - works against {@link ApiModel} and never opens a
+ * specification document itself, so which document formats are understood, and how a particular
+ * quirk of one of them is read, is a fact about the one class that implements this interface, not
+ * about the rest of the tool.
+ *
+ * <p>A specification is written by people, about a system that changed since it was written, so it is
+ * never assumed to be perfect. A document this method cannot read at all - the wrong format, a
+ * declared version nobody implements, a location nothing answers at - is not a reason to stop: it
+ * comes back as an {@link ApiModel} with no operations and an issue explaining why. A document that is
+ * mostly fine but has one broken operation is read as far as it can be, and only that operation is
+ * missing, with the same explanation attached. A caller that wants to know whether everything was
+ * read can ask {@link ApiModel#isComplete()}; a caller that wants to know what to try instead does not
+ * have to catch anything to find out.
+ */
+public interface SpecificationParser {
+
+    /**
+     * Reads the document at the given location.
+     *
+     * @param location where the document is: a file path, a path relative to the classpath, or a URL.
+     *     Never {@code null}
+     * @return the API the document describes, however much of it could be read
+     */
+    ApiModel parse(String location);
+}

--- a/restest-core/src/main/java/module-info.java
+++ b/restest-core/src/main/java/module-info.java
@@ -20,8 +20,8 @@
  * shapes ({@code schema}) that data must follow. Every other part of RESTest is built on top of
  * these definitions.
  *
- * <p>Four packages are exported and one is not. {@code io.restest.core.internal} holds small
- * helpers shared between the other four and is deliberately kept internal, so it can change freely
+ * <p>Five packages are exported and one is not. {@code io.restest.core.internal} holds small
+ * helpers shared between the other five and is deliberately kept internal, so it can change freely
  * without affecting anything built on top of this module.
  *
  * <p>The module requires nothing: no parser, no HTTP client, no constraint solver, no database
@@ -34,4 +34,5 @@ module io.restest.core {
     exports io.restest.core.json;
     exports io.restest.core.model;
     exports io.restest.core.schema;
+    exports io.restest.core.spec;
 }

--- a/restest-spec/pom.xml
+++ b/restest-spec/pom.xml
@@ -21,5 +21,16 @@
             <artifactId>restest-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+        </dependency>
+        <!-- Used directly by VersionGate. Arrives transitively through swagger-parser too, but a
+             dependency this module's own source imports from is declared here in its own right, not
+             left to whatever version swagger-parser happens to pull in. -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/restest-spec/src/main/java/io/restest/spec/OperationConverter.java
+++ b/restest-spec/src/main/java/io/restest/spec/OperationConverter.java
@@ -1,0 +1,541 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.spec;
+
+import io.restest.core.model.HeaderModel;
+import io.restest.core.model.HttpMethod;
+import io.restest.core.model.Operation;
+import io.restest.core.model.OperationId;
+import io.restest.core.model.Parameter;
+import io.restest.core.model.ParameterLocation;
+import io.restest.core.model.ParameterStyle;
+import io.restest.core.model.RequestBodyModel;
+import io.restest.core.model.ResponseModel;
+import io.restest.core.model.Server;
+import io.restest.core.model.ServerVariable;
+import io.restest.core.model.SpecificationIssue;
+import io.restest.core.schema.CanonicalSchema;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Turns the paths and operations of a {@code swagger-parser} document into {@link Operation}s.
+ *
+ * <p>An operation that cannot be represented at all - an unfillable path template, a parameter
+ * declared twice in the same location, a body the document marks required but describes no shape
+ * for - is skipped, never allowed to stop the rest of the document from being read: {@link Operation}
+ * and {@link RequestBodyModel} already refuse to construct those shapes by throwing, which this class
+ * catches and turns into a {@link SpecificationIssue}. Two operations that declare the same
+ * {@code operationId} are not skipped - both stay testable, with the second renamed and the renaming
+ * reported, because {@link io.restest.core.model.ApiModel} requires every identifier to be unique.
+ *
+ * <p>A parameter, request body, response or header may itself be a {@code $ref} to a reusable
+ * definition under {@code components}, and that definition may in turn be a {@code $ref} to another
+ * one - common for a shared "not found" response or a pagination parameter, and confirmed, the hard
+ * way, against real corpus documents that reliably crashed an earlier version of this class.
+ * {@link #resolveChain} follows the whole chain, one lookup into {@code components} at a time; a
+ * chain that does not resolve, or that loops back on a name already seen, is dropped with a
+ * {@link SpecificationIssue#degraded degraded} issue rather than a {@code NullPointerException} or an
+ * infinite loop. A document construct this class does not otherwise guard against - a name missing
+ * where the format requires one, a server with no URL or an unusable variable - is degraded or
+ * skipped the same way, never left to throw past the one operation, server entry or named schema it
+ * belongs to.
+ */
+final class OperationConverter {
+
+    private OperationConverter() {
+    }
+
+    /**
+     * Every operation and issue this document's paths yield.
+     *
+     * @param schemas the document's named schemas, already converted - used only to tell whether an
+     *     operation's data includes something {@link SchemaConverter} could not fully read, without
+     *     resolving each reference a second time
+     */
+    static Result convert(OpenAPI api, Map<String, CanonicalSchema> schemas) {
+        List<Operation> operations = new ArrayList<>();
+        List<SpecificationIssue> issues = new ArrayList<>();
+        Paths paths = api.getPaths();
+        Components components = api.getComponents();
+        if (paths != null) {
+            paths.forEach((path, pathItem) ->
+                    convertPathItem(path, pathItem, components, schemas, operations, issues));
+        }
+        disambiguateOperationIds(operations, issues);
+        return new Result(operations, issues);
+    }
+
+    /**
+     * The API-level, path-level or operation-level servers a document declares, converted in order.
+     * A server declaring no URL at all describes nothing a request could be sent to, and a server
+     * variable that is itself malformed (no default value, or a default outside its own enumerated
+     * values) is one {@link io.restest.core.model.ServerVariable} refuses to construct; either drops
+     * only that one server entry, never the rest of the list or whatever operation was reading it.
+     */
+    static List<Server> convertServers(List<io.swagger.v3.oas.models.servers.Server> servers) {
+        if (servers == null) {
+            return List.of();
+        }
+        List<Server> converted = new ArrayList<>();
+        for (io.swagger.v3.oas.models.servers.Server server : servers) {
+            if (server == null || server.getUrl() == null || server.getUrl().isBlank()) {
+                continue;
+            }
+            try {
+                Map<String, ServerVariable> variables = new LinkedHashMap<>();
+                if (server.getVariables() != null) {
+                    server.getVariables().forEach((name, variable) -> variables.put(name,
+                            new ServerVariable(variable.getDefault(),
+                                    variable.getEnum() == null
+                                            ? List.of() : List.copyOf(variable.getEnum()),
+                                    Optional.ofNullable(variable.getDescription()))));
+                }
+                converted.add(new Server(server.getUrl(), variables,
+                        Optional.ofNullable(server.getDescription())));
+            } catch (IllegalArgumentException ignored) {
+                // A server this malformed describes nothing a request could be sent to either;
+                // dropped the same way one declaring no URL at all already is.
+            }
+        }
+        return converted;
+    }
+
+    private static void convertPathItem(String path, PathItem pathItem, Components components,
+            Map<String, CanonicalSchema> schemas, List<Operation> operations,
+            List<SpecificationIssue> issues) {
+        if (pathItem == null) {
+            return;
+        }
+        if (pathItem.get$ref() != null) {
+            issues.add(SpecificationIssue.document("paths." + path,
+                    "a path item that is itself a reference to another document is not supported yet"));
+            return;
+        }
+        List<io.swagger.v3.oas.models.parameters.Parameter> pathParameters = pathItem.getParameters();
+        List<Server> pathServers = convertServers(pathItem.getServers());
+        pathItem.readOperationsMap().forEach((method, swaggerOperation) -> {
+            String location = "paths." + path + "." + method.name().toLowerCase(Locale.ROOT);
+            Optional<HttpMethod> httpMethod = HttpMethod.named(method.name());
+            if (httpMethod.isEmpty()) {
+                issues.add(SpecificationIssue.skipped(location,
+                        OperationId.of(method.name() + " " + path),
+                        "an HTTP method RESTest does not recognise: '" + method.name() + "'"));
+                return;
+            }
+            OperationId id = declaredOrSynthesised(swaggerOperation, httpMethod.get(), path);
+            try {
+                Operation operation = buildOperation(httpMethod.get(), path, id, pathParameters,
+                        pathServers, swaggerOperation, components, location, issues);
+                operations.add(operation);
+                if (hasUnsupportedConstruct(operation, schemas)) {
+                    issues.add(SpecificationIssue.degraded(location, id, "this operation's data "
+                            + "includes a shape RESTest does not fully understand yet"));
+                }
+            } catch (IllegalArgumentException e) {
+                issues.add(SpecificationIssue.skipped(location, id,
+                        "the operation could not be represented: " + message(e)));
+            }
+        });
+    }
+
+    private static Operation buildOperation(HttpMethod method, String path, OperationId id,
+            List<io.swagger.v3.oas.models.parameters.Parameter> pathParameters,
+            List<Server> pathServers, io.swagger.v3.oas.models.Operation swaggerOperation,
+            Components components, String location, List<SpecificationIssue> issues) {
+        List<Parameter> parameters = mergeParameters(pathParameters, swaggerOperation.getParameters(),
+                components).stream()
+                .flatMap(resolved -> convertParameter(resolved, id, location, issues).stream())
+                .toList();
+        List<Server> operationServers = convertServers(swaggerOperation.getServers());
+        List<Server> servers = operationServers.isEmpty() ? pathServers : operationServers;
+        Optional<RequestBodyModel> requestBody = convertRequestBody(swaggerOperation.getRequestBody(),
+                components, id, location, issues);
+        List<ResponseModel> responses = convertResponses(swaggerOperation.getResponses(), components,
+                id, location, issues);
+        List<String> tags = swaggerOperation.getTags() == null
+                ? List.of() : List.copyOf(swaggerOperation.getTags());
+        Optional<String> summary = Optional.ofNullable(swaggerOperation.getSummary());
+        Optional<String> description = Optional.ofNullable(swaggerOperation.getDescription());
+        boolean deprecated = Boolean.TRUE.equals(swaggerOperation.getDeprecated());
+        return new Operation(id, method, path, servers, parameters, requestBody, responses, tags,
+                summary, description, deprecated);
+    }
+
+    /**
+     * Path-level parameters with the operation's own layered on top, operation winning when both
+     * declare the same name in the same location - the precedence OpenAPI itself defines, regardless
+     * of whether either side is itself a {@code $ref} to a shared parameter (a path-level pagination
+     * parameter overridden by one operation's own is an ordinary document, not an edge case).
+     *
+     * <p>Only a path-level parameter can be shadowed this way. Two operation-level parameters
+     * resolving to the same name and location are not merged into one here - that is a genuine mistake
+     * in the document, not an override, and {@link Operation}'s own constructor is what must see it
+     * and refuse to build, so this method has to let both through rather than quietly picking one.
+     *
+     * <p>Every parameter is resolved here, once, so the override check compares what a parameter
+     * actually is rather than how it was spelled.
+     */
+    private static List<io.swagger.v3.oas.models.parameters.Parameter> mergeParameters(
+            List<io.swagger.v3.oas.models.parameters.Parameter> pathParameters,
+            List<io.swagger.v3.oas.models.parameters.Parameter> operationParameters,
+            Components components) {
+        List<io.swagger.v3.oas.models.parameters.Parameter> ownResolved =
+                (operationParameters == null ? List.<io.swagger.v3.oas.models.parameters.Parameter>of()
+                        : operationParameters).stream()
+                        .map(parameter -> resolveParameter(parameter, components))
+                        .toList();
+
+        Set<String> overriddenByOperation = new HashSet<>();
+        ownResolved.forEach(parameter -> {
+            if (parameter != null) {
+                overriddenByOperation.add(parameterKey(parameter));
+            }
+        });
+
+        List<io.swagger.v3.oas.models.parameters.Parameter> merged = new ArrayList<>();
+        if (pathParameters != null) {
+            for (io.swagger.v3.oas.models.parameters.Parameter raw : pathParameters) {
+                io.swagger.v3.oas.models.parameters.Parameter resolved =
+                        resolveParameter(raw, components);
+                if (resolved != null && overriddenByOperation.contains(parameterKey(resolved))) {
+                    continue;
+                }
+                merged.add(resolved);
+            }
+        }
+        merged.addAll(ownResolved);
+        return merged;
+    }
+
+    private static String parameterKey(io.swagger.v3.oas.models.parameters.Parameter parameter) {
+        return parameter.getIn() + " " + parameter.getName();
+    }
+
+    /**
+     * The parameter itself, or - if it is a {@code $ref}, however many hops deep - the definition the
+     * chain ends at.
+     */
+    private static io.swagger.v3.oas.models.parameters.Parameter resolveParameter(
+            io.swagger.v3.oas.models.parameters.Parameter parameter, Components components) {
+        Map<String, io.swagger.v3.oas.models.parameters.Parameter> pool =
+                components == null ? null : components.getParameters();
+        return resolveChain(parameter, io.swagger.v3.oas.models.parameters.Parameter::get$ref,
+                pool);
+    }
+
+    /**
+     * The converted parameter, or empty if it was a reference that never resolved, or declared no
+     * name to convert it under - reported once, here, rather than letting either reach field access,
+     * or {@link Parameter}'s own constructor, further down.
+     */
+    private static Optional<Parameter> convertParameter(
+            io.swagger.v3.oas.models.parameters.Parameter parameter, OperationId operationId,
+            String location, List<SpecificationIssue> issues) {
+        if (parameter == null) {
+            issues.add(SpecificationIssue.degraded(location, operationId,
+                    "a parameter reference does not resolve to anything the document declares"));
+            return Optional.empty();
+        }
+        if (parameter.getName() == null || parameter.getName().isBlank()) {
+            issues.add(SpecificationIssue.degraded(location, operationId,
+                    "a parameter declares no name to send it under"));
+            return Optional.empty();
+        }
+        ParameterLocation parameterLocation = parameterLocation(parameter.getIn());
+        boolean required = Boolean.TRUE.equals(parameter.getRequired());
+        Optional<String> description = Optional.ofNullable(parameter.getDescription());
+        if (parameter.getContent() != null && !parameter.getContent().isEmpty()) {
+            Map.Entry<String, io.swagger.v3.oas.models.media.MediaType> entry =
+                    parameter.getContent().entrySet().iterator().next();
+            CanonicalSchema schema = SchemaConverter.convert(entry.getValue().getSchema());
+            return Optional.of(new Parameter(parameter.getName(), parameterLocation, required, schema,
+                    ParameterStyle.defaultFor(parameterLocation), false, Optional.of(entry.getKey()),
+                    description));
+        }
+        CanonicalSchema schema = SchemaConverter.convert(parameter.getSchema());
+        ParameterStyle style = parameterStyle(parameter.getStyle(), parameterLocation);
+        boolean explode = parameter.getExplode() != null
+                ? parameter.getExplode() : style.explodesByDefault();
+        return Optional.of(new Parameter(parameter.getName(), parameterLocation, required, schema,
+                style, explode, Optional.empty(), description));
+    }
+
+    /**
+     * OpenAPI 2.0's {@code in: body} and {@code in: formData} - the two locations {@link
+     * ParameterLocation} deliberately has no case for - never reach here: {@code swagger-parser}
+     * converts a 2.0 document to a 3.0 one, request body and all, before this class ever sees it
+     * (confirmed empirically against the corpus). A location string outside the four this format
+     * actually defines, or absent entirely, should not occur; defaulting to {@code QUERY} keeps the
+     * parameter testable rather than losing it, on the rare chance it does.
+     */
+    private static ParameterLocation parameterLocation(String in) {
+        return switch (in) {
+            case "path" -> ParameterLocation.PATH;
+            case "header" -> ParameterLocation.HEADER;
+            case "cookie" -> ParameterLocation.COOKIE;
+            case null, default -> ParameterLocation.QUERY;
+        };
+    }
+
+    private static ParameterStyle parameterStyle(
+            io.swagger.v3.oas.models.parameters.Parameter.StyleEnum style,
+            ParameterLocation location) {
+        if (style == null) {
+            return ParameterStyle.defaultFor(location);
+        }
+        return switch (style) {
+            case MATRIX -> ParameterStyle.MATRIX;
+            case LABEL -> ParameterStyle.LABEL;
+            case FORM -> ParameterStyle.FORM;
+            case SIMPLE -> ParameterStyle.SIMPLE;
+            case SPACEDELIMITED -> ParameterStyle.SPACE_DELIMITED;
+            case PIPEDELIMITED -> ParameterStyle.PIPE_DELIMITED;
+            case DEEPOBJECT -> ParameterStyle.DEEP_OBJECT;
+        };
+    }
+
+    private static Optional<RequestBodyModel> convertRequestBody(RequestBody requestBody,
+            Components components, OperationId operationId, String location,
+            List<SpecificationIssue> issues) {
+        if (requestBody == null) {
+            return Optional.empty();
+        }
+        boolean wasReference = requestBody.get$ref() != null;
+        RequestBody resolved = resolveRequestBody(requestBody, components);
+        if (resolved == null) {
+            if (wasReference) {
+                issues.add(SpecificationIssue.degraded(location, operationId,
+                        "a request body reference does not resolve to anything the document declares"));
+            }
+            return Optional.empty();
+        }
+        boolean required = Boolean.TRUE.equals(resolved.getRequired());
+        Map<String, CanonicalSchema> content = convertContent(resolved.getContent());
+        return Optional.of(new RequestBodyModel(required, content,
+                Optional.ofNullable(resolved.getDescription())));
+    }
+
+    /**
+     * The request body itself, or - if it is a {@code $ref}, however many hops deep - the definition
+     * the chain ends at.
+     */
+    private static RequestBody resolveRequestBody(RequestBody requestBody, Components components) {
+        Map<String, RequestBody> pool = components == null ? null : components.getRequestBodies();
+        return resolveChain(requestBody, RequestBody::get$ref, pool);
+    }
+
+    private static List<ResponseModel> convertResponses(ApiResponses responses, Components components,
+            OperationId operationId, String location, List<SpecificationIssue> issues) {
+        if (responses == null) {
+            return List.of();
+        }
+        List<ResponseModel> converted = new ArrayList<>();
+        responses.forEach((status, response) -> {
+            boolean wasReference = response != null && response.get$ref() != null;
+            ApiResponse resolved = resolveResponse(response, components);
+            if (resolved == null) {
+                if (wasReference) {
+                    issues.add(SpecificationIssue.degraded(location, operationId, "the response '"
+                            + status + "' is a reference that does not resolve to anything the "
+                            + "document declares"));
+                }
+                return;
+            }
+            Map<String, CanonicalSchema> content = convertContent(resolved.getContent());
+            Map<String, HeaderModel> headers = convertHeaders(resolved.getHeaders(), components,
+                    operationId, location, issues);
+            try {
+                converted.add(new ResponseModel(status, content, headers,
+                        Optional.ofNullable(resolved.getDescription())));
+            } catch (IllegalArgumentException e) {
+                // A malformed response - most often an unusable status key - costs only itself: the
+                // operation is still testable against whatever it does answer correctly.
+                issues.add(SpecificationIssue.degraded(location, operationId,
+                        "the response '" + status + "' could not be represented: " + message(e)));
+            }
+        });
+        return converted;
+    }
+
+    /**
+     * The response itself, or - if it is a {@code $ref}, however many hops deep - the definition the
+     * chain ends at.
+     */
+    private static ApiResponse resolveResponse(ApiResponse response, Components components) {
+        Map<String, ApiResponse> pool = components == null ? null : components.getResponses();
+        return resolveChain(response, ApiResponse::get$ref, pool);
+    }
+
+    private static Map<String, HeaderModel> convertHeaders(Map<String, Header> headers,
+            Components components, OperationId operationId, String location,
+            List<SpecificationIssue> issues) {
+        if (headers == null) {
+            return Map.of();
+        }
+        Map<String, HeaderModel> converted = new LinkedHashMap<>();
+        headers.forEach((name, header) -> {
+            boolean wasReference = header != null && header.get$ref() != null;
+            Header resolved = resolveHeader(header, components);
+            if (resolved == null) {
+                if (wasReference) {
+                    issues.add(SpecificationIssue.degraded(location, operationId, "the header '" + name
+                            + "' is a reference that does not resolve to anything the document "
+                            + "declares"));
+                }
+                return;
+            }
+            converted.put(name, new HeaderModel(Boolean.TRUE.equals(resolved.getRequired()),
+                    SchemaConverter.convert(resolved.getSchema()),
+                    Optional.ofNullable(resolved.getDescription())));
+        });
+        return converted;
+    }
+
+    /**
+     * The header itself, or - if it is a {@code $ref}, however many hops deep - the definition the
+     * chain ends at.
+     */
+    private static Header resolveHeader(Header header, Components components) {
+        Map<String, Header> pool = components == null ? null : components.getHeaders();
+        return resolveChain(header, Header::get$ref, pool);
+    }
+
+    /**
+     * Follows a {@code $ref} chain to whatever it ultimately names, one lookup at a time: the given
+     * value if it is not a reference at all, {@code null} if any link is missing from {@code pool} or
+     * the chain revisits a name already seen (a cycle, which a well-formed document should never
+     * contain, but nothing here assumes it does not).
+     */
+    private static <T> T resolveChain(T value, Function<T, String> ref, Map<String, T> pool) {
+        Set<String> visited = new HashSet<>();
+        T current = value;
+        while (current != null) {
+            String reference = ref.apply(current);
+            if (reference == null) {
+                return current;
+            }
+            if (!visited.add(reference) || pool == null) {
+                return null;
+            }
+            current = pool.get(refName(reference));
+        }
+        return null;
+    }
+
+    private static Map<String, CanonicalSchema> convertContent(Content content) {
+        if (content == null) {
+            return Map.of();
+        }
+        Map<String, CanonicalSchema> converted = new LinkedHashMap<>();
+        content.forEach((mediaType, value) -> converted.put(mediaType,
+                SchemaConverter.convert(value.getSchema())));
+        return converted;
+    }
+
+    /** The name a {@code $ref} points at: {@code Pet} for {@code #/components/parameters/Pet}. */
+    private static String refName(String ref) {
+        int lastSlash = ref.lastIndexOf('/');
+        return lastSlash < 0 ? ref : ref.substring(lastSlash + 1);
+    }
+
+    private static OperationId declaredOrSynthesised(io.swagger.v3.oas.models.Operation swaggerOperation,
+            HttpMethod method, String path) {
+        String declared = swaggerOperation.getOperationId();
+        return declared != null && !declared.isBlank()
+                ? OperationId.of(declared) : OperationId.synthesised(method, path);
+    }
+
+    /**
+     * Two operations sharing one {@code operationId} is a contradiction {@link
+     * io.restest.core.model.ApiModel} refuses to hold; the second (and any further collision) is
+     * renamed to its synthesised, always-unique identifier, and the renaming is reported so a reader
+     * knows why an operation's identifier does not match what the document declared.
+     */
+    private static void disambiguateOperationIds(List<Operation> operations,
+            List<SpecificationIssue> issues) {
+        Set<OperationId> seen = new LinkedHashSet<>();
+        for (int i = 0; i < operations.size(); i++) {
+            Operation operation = operations.get(i);
+            if (seen.add(operation.id())) {
+                continue;
+            }
+            OperationId unique = OperationId.synthesised(operation.method(), operation.path());
+            int suffix = 2;
+            while (!seen.add(unique)) {
+                unique = OperationId.of(operation.method() + " " + operation.path() + " (" + suffix + ")");
+                suffix++;
+            }
+            operations.set(i, operation.withId(unique));
+            String location = "paths." + operation.path() + "."
+                    + operation.method().name().toLowerCase(Locale.ROOT);
+            issues.add(SpecificationIssue.degraded(location, unique, "the document declares this "
+                    + "operation's identifier more than once; renamed to stay unique"));
+        }
+    }
+
+    private static boolean hasUnsupportedConstruct(Operation operation,
+            Map<String, CanonicalSchema> schemas) {
+        for (Parameter parameter : operation.parameters()) {
+            if (SchemaConverter.hasUnsupportedConstruct(parameter.schema(), schemas)) {
+                return true;
+            }
+        }
+        if (operation.requestBody().isPresent()
+                && operation.requestBody().get().content().values().stream()
+                        .anyMatch(schema -> SchemaConverter.hasUnsupportedConstruct(schema, schemas))) {
+            return true;
+        }
+        for (ResponseModel response : operation.responses()) {
+            if (response.content().values().stream()
+                    .anyMatch(schema -> SchemaConverter.hasUnsupportedConstruct(schema, schemas))) {
+                return true;
+            }
+            for (HeaderModel header : response.headers().values()) {
+                if (SchemaConverter.hasUnsupportedConstruct(header.schema(), schemas)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /** An exception's own message, or its class name when it declined to leave one. */
+    private static String message(Exception e) {
+        return e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+    }
+
+    /** Everything reading a document's paths produces: the operations, and what could not be read. */
+    record Result(List<Operation> operations, List<SpecificationIssue> issues) {
+    }
+}

--- a/restest-spec/src/main/java/io/restest/spec/SchemaConverter.java
+++ b/restest-spec/src/main/java/io/restest/spec/SchemaConverter.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.spec;
+
+import io.restest.core.json.JsonValue;
+import io.restest.core.schema.AnySchema;
+import io.restest.core.schema.ArraySchema;
+import io.restest.core.schema.BooleanSchema;
+import io.restest.core.schema.CanonicalSchema;
+import io.restest.core.schema.NothingSchema;
+import io.restest.core.schema.NullSchema;
+import io.restest.core.schema.NumberKind;
+import io.restest.core.schema.NumberSchema;
+import io.restest.core.schema.ObjectSchema;
+import io.restest.core.schema.SchemaMetadata;
+import io.restest.core.schema.SchemaReference;
+import io.restest.core.schema.StringSchema;
+import io.restest.core.schema.UnsupportedSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Turns one {@code swagger-parser} schema into the ten-shape {@link CanonicalSchema} the rest of
+ * RESTest works with.
+ *
+ * <p>Composition (a value declared as one of several alternative shapes, {@code oneOf}/{@code anyOf}/
+ * {@code allOf}/{@code not}/a discriminator) and tuple-form arrays ({@code prefixItems}, where every
+ * element has its own declared shape) are read as {@link UnsupportedSchema}: folding composition into
+ * the canonical model is a later increment, and a tuple is not the "every element looks the same"
+ * shape {@link ArraySchema} represents. Neither crashes the parser; both say why in the report.
+ */
+final class SchemaConverter {
+
+    private SchemaConverter() {
+    }
+
+    /** The canonical shape for the given schema, or {@link AnySchema} for {@code null}. */
+    static CanonicalSchema convert(Schema<?> schema) {
+        if (schema == null) {
+            return AnySchema.of();
+        }
+        if (schema.get$ref() != null) {
+            return new SchemaReference(metadataOf(schema), refName(schema.get$ref()));
+        }
+        SchemaMetadata metadata = metadataOf(schema);
+        if (isComposed(schema)) {
+            return new UnsupportedSchema(metadata, "a value declared as one of several alternative "
+                    + "shapes (oneOf/anyOf/allOf/not) is not supported yet");
+        }
+        if (schema.getPrefixItems() != null && !schema.getPrefixItems().isEmpty()) {
+            return new UnsupportedSchema(metadata, "a tuple-form array, where each element has its "
+                    + "own declared shape (prefixItems), is not supported yet");
+        }
+        Set<String> nonNullTypes = nonNullTypes(schema);
+        if (nonNullTypes.size() > 1) {
+            return new UnsupportedSchema(metadata, "a value declared as one of several plain JSON "
+                    + "Schema types (" + String.join(", ", nonNullTypes) + ") is not supported yet");
+        }
+        String type = effectiveType(schema);
+        return switch (type) {
+            case "object" -> convertObject(schema, metadata);
+            case "array" -> convertArray(schema, metadata);
+            case "string" -> convertString(schema, metadata);
+            case "integer" -> convertNumber(schema, metadata, NumberKind.INTEGER);
+            case "number" -> convertNumber(schema, metadata, NumberKind.NUMBER);
+            case "boolean" -> new BooleanSchema(metadata);
+            case "null" -> new NullSchema(metadata);
+            case null -> new AnySchema(metadata);
+            default -> new UnsupportedSchema(metadata, "an unrecognised schema type: '" + type + "'");
+        };
+    }
+
+    /**
+     * Whether any part of the given schema is, or contains, {@link UnsupportedSchema} - resolving a
+     * {@link SchemaReference} against the given named schemas one level at a time, so a body that is
+     * only a {@code $ref} to a composed schema is not reported as perfectly fine just because the
+     * reference itself is a plain, resolvable name. A name already visited on this walk is treated as
+     * not (newly) unsupported rather than resolved again, so a schema that refers to itself, directly
+     * or through others, cannot recurse for ever.
+     */
+    static boolean hasUnsupportedConstruct(CanonicalSchema schema, Map<String, CanonicalSchema> schemas) {
+        return hasUnsupportedConstruct(schema, schemas, new HashSet<>());
+    }
+
+    /** {@link #hasUnsupportedConstruct(CanonicalSchema, Map)}, without following any reference. */
+    static boolean hasUnsupportedConstruct(CanonicalSchema schema) {
+        return hasUnsupportedConstruct(schema, Map.of());
+    }
+
+    private static boolean hasUnsupportedConstruct(CanonicalSchema schema,
+            Map<String, CanonicalSchema> schemas, Set<String> visited) {
+        return switch (schema) {
+            case UnsupportedSchema u -> true;
+            case ObjectSchema o -> o.properties().values().stream()
+                    .anyMatch(v -> hasUnsupportedConstruct(v, schemas, visited))
+                    || o.additionalProperties().map(v -> hasUnsupportedConstruct(v, schemas, visited))
+                            .orElse(false);
+            case ArraySchema a -> hasUnsupportedConstruct(a.items(), schemas, visited);
+            case SchemaReference r -> {
+                if (!visited.add(r.name())) {
+                    yield false;
+                }
+                CanonicalSchema target = schemas.get(r.name());
+                yield target != null && hasUnsupportedConstruct(target, schemas, visited);
+            }
+            case AnySchema ignored -> false;
+            case BooleanSchema ignored -> false;
+            case NothingSchema ignored -> false;
+            case NullSchema ignored -> false;
+            case NumberSchema ignored -> false;
+            case StringSchema ignored -> false;
+        };
+    }
+
+    private static boolean isComposed(Schema<?> schema) {
+        return isNonEmpty(schema.getOneOf()) || isNonEmpty(schema.getAnyOf())
+                || isNonEmpty(schema.getAllOf()) || schema.getNot() != null
+                || schema.getDiscriminator() != null;
+    }
+
+    private static boolean isNonEmpty(List<?> list) {
+        return list != null && !list.isEmpty();
+    }
+
+    /**
+     * The type declared for this schema: from {@code type} (OAS 3.0) or, when that is absent, from
+     * the single non-{@code "null"} member of {@code types} (OAS 3.1's type array). {@code null}
+     * when neither declares one - which is a schema that accepts any value, {@link AnySchema}. Not
+     * meaningful when {@link #nonNullTypes} has more than one member; callers check that first.
+     */
+    private static String effectiveType(Schema<?> schema) {
+        if (schema.getType() != null) {
+            return schema.getType();
+        }
+        return nonNullTypes(schema).stream().findFirst().orElse(null);
+    }
+
+    /**
+     * The non-{@code "null"} members of OAS 3.1's {@code types} array. A JSON Schema type array can
+     * name more than one real type - {@code [string, integer]}, a plain union, distinct from
+     * nullability - which none of the ten canonical shapes can represent; more than one member here
+     * is the signal for that, checked before {@link #effectiveType} ever has to pick just one.
+     */
+    private static Set<String> nonNullTypes(Schema<?> schema) {
+        if (schema.getTypes() == null) {
+            return Set.of();
+        }
+        return schema.getTypes().stream().filter(candidate -> !"null".equals(candidate))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private static ObjectSchema convertObject(Schema<?> schema, SchemaMetadata metadata) {
+        Map<String, CanonicalSchema> properties = new LinkedHashMap<>();
+        if (schema.getProperties() != null) {
+            schema.getProperties().forEach((name, value) -> properties.put(name, convert(value)));
+        }
+        Set<String> required = schema.getRequired() == null
+                ? Set.of() : new LinkedHashSet<>(schema.getRequired());
+        Optional<CanonicalSchema> additionalProperties = convertAdditionalProperties(
+                schema.getAdditionalProperties());
+        Optional<Integer> minProperties = Optional.ofNullable(schema.getMinProperties());
+        Optional<Integer> maxProperties = Optional.ofNullable(schema.getMaxProperties());
+        return new ObjectSchema(metadata, properties, required, additionalProperties, minProperties,
+                maxProperties);
+    }
+
+    private static Optional<CanonicalSchema> convertAdditionalProperties(Object additionalProperties) {
+        if (additionalProperties == null) {
+            return Optional.empty();
+        }
+        if (additionalProperties instanceof Boolean allowed) {
+            return allowed ? Optional.empty() : Optional.of(NothingSchema.of());
+        }
+        if (additionalProperties instanceof Schema<?> nested) {
+            return Optional.of(convert(nested));
+        }
+        return Optional.empty();
+    }
+
+    private static ArraySchema convertArray(Schema<?> schema, SchemaMetadata metadata) {
+        CanonicalSchema items = convert(schema.getItems());
+        Optional<Integer> minItems = Optional.ofNullable(schema.getMinItems());
+        Optional<Integer> maxItems = Optional.ofNullable(schema.getMaxItems());
+        boolean uniqueItems = Boolean.TRUE.equals(schema.getUniqueItems());
+        return new ArraySchema(metadata, items, minItems, maxItems, uniqueItems);
+    }
+
+    private static StringSchema convertString(Schema<?> schema, SchemaMetadata metadata) {
+        Optional<Integer> minLength = Optional.ofNullable(schema.getMinLength());
+        Optional<Integer> maxLength = Optional.ofNullable(schema.getMaxLength());
+        Optional<String> pattern = Optional.ofNullable(schema.getPattern());
+        Optional<String> format = Optional.ofNullable(schema.getFormat());
+        return new StringSchema(metadata, minLength, maxLength, pattern, format);
+    }
+
+    private static NumberSchema convertNumber(Schema<?> schema, SchemaMetadata metadata,
+            NumberKind kind) {
+        BigDecimal minimum = schema.getMinimum();
+        BigDecimal exclusiveMinimum = schema.getExclusiveMinimumValue();
+        if (exclusiveMinimum == null && Boolean.TRUE.equals(schema.getExclusiveMinimum())) {
+            // OAS 3.0: exclusiveMinimum is a flag next to `minimum`, not a bound of its own.
+            exclusiveMinimum = minimum;
+            minimum = null;
+        }
+        BigDecimal maximum = schema.getMaximum();
+        BigDecimal exclusiveMaximum = schema.getExclusiveMaximumValue();
+        if (exclusiveMaximum == null && Boolean.TRUE.equals(schema.getExclusiveMaximum())) {
+            exclusiveMaximum = maximum;
+            maximum = null;
+        }
+        return new NumberSchema(metadata, kind, Optional.ofNullable(minimum),
+                Optional.ofNullable(exclusiveMinimum), Optional.ofNullable(maximum),
+                Optional.ofNullable(exclusiveMaximum), Optional.ofNullable(schema.getMultipleOf()),
+                Optional.ofNullable(schema.getFormat()));
+    }
+
+    private static SchemaMetadata metadataOf(Schema<?> schema) {
+        Optional<String> description = Optional.ofNullable(schema.getDescription());
+        boolean nullable = Boolean.TRUE.equals(schema.getNullable())
+                || (schema.getTypes() != null && schema.getTypes().contains("null"));
+        List<JsonValue> enumeration = schema.getEnum() == null
+                ? List.of()
+                : schema.getEnum().stream().map(SchemaConverter::toJsonValue).toList();
+        Optional<JsonValue> defaultValue = schema.getDefault() == null
+                ? Optional.empty() : Optional.of(toJsonValue(schema.getDefault()));
+        boolean deprecated = Boolean.TRUE.equals(schema.getDeprecated());
+        SchemaMetadata.Access access = Boolean.TRUE.equals(schema.getReadOnly())
+                ? SchemaMetadata.Access.READ_ONLY
+                : Boolean.TRUE.equals(schema.getWriteOnly())
+                        ? SchemaMetadata.Access.WRITE_ONLY
+                        : SchemaMetadata.Access.READ_WRITE;
+        return new SchemaMetadata(description, nullable, enumeration, defaultValue, deprecated, access);
+    }
+
+    /**
+     * The name a {@code $ref} points at: {@code Pet} for {@code #/components/schemas/Pet}, and also
+     * for {@code ./other-file.yaml#/components/schemas/Pet} - {@link SchemaReference} resolves by
+     * name alone within the one document {@link io.restest.core.model.ApiModel} holds, so a reference
+     * into a different file is read the same way a local one is, file part discarded. A multi-file
+     * specification where a schema of that name is also declared locally therefore resolves to the
+     * local one, not the external one, without anything here able to tell the two apart. Widening
+     * {@code SchemaReference} to also carry where a name came from would be the fix; that is a change
+     * to the canonical model itself, not something to decide in a converter.
+     */
+    private static String refName(String ref) {
+        Objects.requireNonNull(ref, "ref");
+        int lastSlash = ref.lastIndexOf('/');
+        return lastSlash < 0 ? ref : ref.substring(lastSlash + 1);
+    }
+
+    /** A raw value from the parsed document (Jackson's own types) as a {@link JsonValue}. */
+    private static JsonValue toJsonValue(Object value) {
+        return switch (value) {
+            case null -> JsonValue.NULL;
+            case Boolean b -> JsonValue.of(b);
+            case BigDecimal d -> JsonValue.of(d);
+            case Integer i -> JsonValue.of(i.longValue());
+            case Long l -> JsonValue.of(l);
+            case Double d -> JsonValue.of(BigDecimal.valueOf(d));
+            case Float f -> JsonValue.of(BigDecimal.valueOf(f));
+            case String s -> JsonValue.of(s);
+            case List<?> list -> {
+                List<JsonValue> elements = new ArrayList<>();
+                list.forEach(element -> elements.add(toJsonValue(element)));
+                yield JsonValue.array(elements);
+            }
+            case Map<?, ?> map -> {
+                Map<String, JsonValue> members = new LinkedHashMap<>();
+                map.forEach((key, value2) -> members.put(String.valueOf(key), toJsonValue(value2)));
+                yield JsonValue.object(members);
+            }
+            default -> JsonValue.of(String.valueOf(value));
+        };
+    }
+}

--- a/restest-spec/src/main/java/io/restest/spec/SwaggerSpecificationParser.java
+++ b/restest-spec/src/main/java/io/restest/spec/SwaggerSpecificationParser.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.spec;
+
+import io.restest.core.model.ApiModel;
+import io.restest.core.model.Server;
+import io.restest.core.model.SpecificationIssue;
+import io.restest.core.schema.CanonicalSchema;
+import io.restest.core.schema.UnsupportedSchema;
+import io.restest.core.spec.SpecificationParser;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Reads an OpenAPI or Swagger document with {@code swagger-parser}, the only place in RESTest that
+ * does.
+ *
+ * <p>{@code swagger-parser} is trusted for exactly one thing: turning a document already known to be
+ * OAS 2.0 (which it converts to 3.0 itself, before this class ever sees it), 3.0.x or 3.1.x into
+ * Java objects. Everything about whether the document is safe to hand it, and everything about
+ * turning those objects into RESTest's own model, is this module's job - see {@link VersionGate},
+ * {@link SchemaConverter} and {@link OperationConverter}.
+ *
+ * <p>Nothing here throws for a problem with the document itself. A location nothing answers at, text
+ * that is not valid YAML or JSON, a declared version out of scope, an operation that cannot be
+ * represented - each becomes an {@link ApiModel} with an issue attached, never an exception. Because a
+ * hand-written or machine-generated document can be wrong in ways no amount of individually-guarded
+ * code anticipates, converting the parsed document into RESTest's model runs under one last, general
+ * guard too, but only around whatever a more specific guard has not already caught closer to the
+ * construct that broke - named schemas and servers are each guarded where they are read, precisely so
+ * that a single bad one costs only itself, never every operation in the document.
+ */
+public final class SwaggerSpecificationParser implements SpecificationParser {
+
+    /** Generous, but not unbounded: a hung server must not hang the run that asked for its document. */
+    private static final int URL_TIMEOUT_MILLIS = 10_000;
+
+    /** Far larger than any real specification; a bound against an unbounded or hostile response. */
+    private static final int MAX_DOCUMENT_BYTES = 64 * 1024 * 1024;
+
+    @Override
+    public ApiModel parse(String location) {
+        if (location == null || location.isBlank()) {
+            return incomplete(SpecificationIssue.document("location", "no location was given"));
+        }
+
+        Optional<String> content = read(location);
+        if (content.isEmpty()) {
+            return incomplete(SpecificationIssue.document("location",
+                    "nothing could be read from '" + location + "'"));
+        }
+
+        Optional<String> unsupported = VersionGate.unsupportedReason(content.get());
+        if (unsupported.isPresent()) {
+            return incomplete(SpecificationIssue.document("info", unsupported.get()));
+        }
+
+        ParseOptions options = new ParseOptions();
+        options.setResolve(false);
+        SwaggerParseResult result = new OpenAPIParser().readContents(content.get(), null, options);
+        OpenAPI api = result.getOpenAPI();
+        List<String> messages = result.getMessages();
+        if (api == null) {
+            String reason = messages == null || messages.isEmpty()
+                    ? "the document could not be read" : String.join("; ", messages);
+            return incomplete(SpecificationIssue.document("info", reason));
+        }
+
+        try {
+            return toApiModel(api, messages);
+        } catch (RuntimeException e) {
+            // Every construct this class knows to expect is already guarded, specifically, closer to
+            // where it can go wrong. This is the backstop for the one it does not yet know about: the
+            // rule that a bad document degrades the run, not this one exception's job to enumerate.
+            return incomplete(SpecificationIssue.document("info",
+                    "the document could not be fully converted: "
+                            + (e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName())));
+        }
+    }
+
+    private static ApiModel toApiModel(OpenAPI api, List<String> backendMessages) {
+        Info info = api.getInfo();
+        String title = info != null && info.getTitle() != null ? info.getTitle() : "";
+        String version = info != null && info.getVersion() != null ? info.getVersion() : "";
+        List<Server> servers = OperationConverter.convertServers(api.getServers());
+
+        List<SpecificationIssue> documentIssues = new ArrayList<>();
+        if (backendMessages != null) {
+            backendMessages.forEach(message ->
+                    documentIssues.add(SpecificationIssue.document("info", message)));
+        }
+
+        Map<String, CanonicalSchema> schemas = new LinkedHashMap<>();
+        if (api.getComponents() != null && api.getComponents().getSchemas() != null) {
+            api.getComponents().getSchemas().forEach((name, schema) -> {
+                CanonicalSchema converted;
+                try {
+                    converted = SchemaConverter.convert(schema);
+                } catch (IllegalArgumentException e) {
+                    // A named schema this malformed is still named: keeping the entry, as something
+                    // unsupported, means an operation that references it is degraded, correctly,
+                    // rather than the reference silently resolving to nothing.
+                    String reason = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+                    converted = UnsupportedSchema.of("could not be represented: " + reason);
+                    documentIssues.add(SpecificationIssue.document("components.schemas." + name,
+                            "this schema could not be represented: " + reason));
+                }
+                schemas.put(name, converted);
+            });
+        }
+        schemas.forEach((name, schema) -> {
+            if (SchemaConverter.hasUnsupportedConstruct(schema, schemas)) {
+                documentIssues.add(SpecificationIssue.document("components.schemas." + name,
+                        "this schema includes a shape RESTest does not fully understand yet"));
+            }
+        });
+
+        OperationConverter.Result operations = OperationConverter.convert(api, schemas);
+
+        List<SpecificationIssue> issues = new ArrayList<>(documentIssues);
+        issues.addAll(operations.issues());
+
+        return new ApiModel(title, version, servers, operations.operations(), schemas, issues);
+    }
+
+    private static ApiModel incomplete(SpecificationIssue issue) {
+        return new ApiModel("", "", List.of(), List.of(), Map.of(), List.of(issue));
+    }
+
+    /**
+     * The document's raw text, from a file path, a path relative to the classpath, or a URL - in that
+     * order. Empty when none of the three produced anything, which is the one signal
+     * {@code swagger-parser} itself does not give: fed a location nothing answers at, it returns a
+     * {@code null} result and {@code null} messages, confirmed empirically while building this class.
+     *
+     * <p>Read as bytes and decoded leniently rather than with a decoder that throws, so a file that
+     * exists but is not valid UTF-8 is reported for what it is - unreadable content - rather than
+     * mistaken for a location nothing answered at.
+     */
+    private static Optional<String> read(String location) {
+        try {
+            Path path = Path.of(location);
+            if (Files.isReadable(path) && !Files.isDirectory(path)) {
+                return Optional.of(decode(Files.readAllBytes(path)));
+            }
+        } catch (InvalidPathException | IOException ignored) {
+            // Falls through: not every location is a valid local path, and that is not an error yet.
+        }
+        try (InputStream stream = SwaggerSpecificationParser.class.getClassLoader()
+                .getResourceAsStream(location)) {
+            if (stream != null) {
+                return Optional.of(decode(readBounded(stream)));
+            }
+        } catch (IOException ignored) {
+            // Falls through to the URL attempt.
+        }
+        if (location.startsWith("http://") || location.startsWith("https://")) {
+            try {
+                URLConnection connection = URI.create(location).toURL().openConnection();
+                connection.setConnectTimeout(URL_TIMEOUT_MILLIS);
+                connection.setReadTimeout(URL_TIMEOUT_MILLIS);
+                try (InputStream stream = connection.getInputStream()) {
+                    return Optional.of(decode(readBounded(stream)));
+                }
+            } catch (IOException | IllegalArgumentException ignored) {
+                // A malformed URL (an illegal character, for instance) is exactly as unreachable as
+                // one that is well-formed but answers nothing; both report the same way.
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Every byte, up to a ceiling no real specification approaches - a bound against an unbounded or
+     * hostile response, not a claim about how large a real document can be.
+     */
+    private static byte[] readBounded(InputStream stream) throws IOException {
+        return stream.readNBytes(MAX_DOCUMENT_BYTES);
+    }
+
+    private static String decode(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+}

--- a/restest-spec/src/main/java/io/restest/spec/VersionGate.java
+++ b/restest-spec/src/main/java/io/restest/spec/VersionGate.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.spec;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Decides whether a document's own declared version is one the parser backend may be trusted with,
+ * before it ever sees the document.
+ *
+ * <p>Fed a document it does not recognise, the backend does not fail cleanly: given
+ * {@code openapi: 3.2.0}, it has been seen to return messages that never mention 3.2 at all, and a
+ * non-null result that silently claims a different version - confirmed while building this class.
+ * Trusting its output to decide "is this version supported" would sometimes get the answer wrong.
+ * This class reads the one fact it needs - the declared version - directly, with a plain YAML load
+ * (YAML is a superset of JSON, so one code path covers both corpus formats), and the backend is only
+ * ever invoked once that fact is already known to be in scope: OAS 2.0, 3.0.x and 3.1.x.
+ *
+ * <p>Charitable on purpose: a bare {@code 3.0} (no patch number), surrounding whitespace, and a
+ * trailing pre-release or build tag ({@code 3.0.1-rc1}) are all read as the version they plainly are,
+ * not rejected on a technicality a real document is entitled to have.
+ */
+final class VersionGate {
+
+    private static final Pattern SUPPORTED = Pattern.compile("2\\.0|3\\.[01](\\.\\d+)?([-+].*)?");
+
+    /**
+     * SnakeYAML refuses, by default, to load a document past roughly three million characters - a
+     * guard against decompression-bomb-style input that is far too small for a real specification;
+     * the largest one in this project's own corpus is already most of the way there. This is a
+     * generous ceiling for peeking at one top-level key, not an endorsement of documents this large.
+     */
+    private static final int CODE_POINT_LIMIT = 100_000_000;
+
+    /**
+     * SnakeYAML's default nesting-depth guard, 50, is comfortably deep for a document written by
+     * hand but not for one a code generator produced: a schema with a property of a property of a
+     * property, twenty-odd levels deep, is unusual but real, and the backend this gate hands off to
+     * (Jackson, whose own default limit is 1000) would read it without complaint. Raised here to the
+     * same order of magnitude, so the gate is not the reason such a document is rejected.
+     */
+    private static final int NESTING_DEPTH_LIMIT = 1_000;
+
+    private VersionGate() {
+    }
+
+    /** Empty when the declared version is in scope; otherwise, why it is not. */
+    static Optional<String> unsupportedReason(String content) {
+        Object document;
+        try {
+            LoaderOptions options = new LoaderOptions();
+            options.setCodePointLimit(CODE_POINT_LIMIT);
+            options.setNestingDepthLimit(NESTING_DEPTH_LIMIT);
+            document = new Yaml(options).load(content);
+        } catch (RuntimeException e) {
+            return Optional.of("the document is not valid YAML or JSON: " + firstLine(e.getMessage()));
+        }
+        if (!(document instanceof Map<?, ?> map)) {
+            return Optional.of("the document is not a YAML/JSON object");
+        }
+        Object declared = map.containsKey("openapi") ? map.get("openapi") : map.get("swagger");
+        if (declared == null) {
+            return Optional.of("the document declares neither 'openapi' nor 'swagger'");
+        }
+        String version = String.valueOf(declared).trim();
+        if (!SUPPORTED.matcher(version).matches()) {
+            return Optional.of("the document declares version '" + version + "', which is out of "
+                    + "scope (2.0, 3.0.x and 3.1.x are supported)");
+        }
+        return Optional.empty();
+    }
+
+    private static String firstLine(String message) {
+        if (message == null) {
+            return "malformed";
+        }
+        int newline = message.indexOf('\n');
+        return newline < 0 ? message : message.substring(0, newline);
+    }
+}

--- a/restest-spec/src/main/java/module-info.java
+++ b/restest-spec/src/main/java/module-info.java
@@ -1,3 +1,38 @@
+/**
+ * The specification parser. The only module allowed to reference {@code io.swagger}.
+ *
+ * <p>Exports {@code io.restest.spec} so a caller can construct {@code SwaggerSpecificationParser}
+ * directly. The {@code provides} declaration for {@code SpecificationParser} does not yet do
+ * anything on its own - nothing in this project runs {@code ServiceLoader.load} against the
+ * interface, and no consuming module declares {@code uses} - it is here so that when one does, this
+ * module is already ready to be found rather than needing a second change alongside the first
+ * consumer, at no cost while nothing looks for it.
+ *
+ * <p>Two of the required modules are not named by an import anywhere in this module's own code:
+ * {@code swagger.parser} and {@code swagger.parser.core} are automatic modules (their jars carry no
+ * {@code Automatic-Module-Name}, so the name is derived from the jar's filename - the build's own
+ * warning about this is expected, not a defect to fix), and the parser library's own internal
+ * delegation between its jars happens without this module's {@code requires} needing to mention
+ * every one of them: an automatic module can read every other module on the path regardless of what
+ * named this one. What is required here is exactly what this module's own source imports from -
+ * confirmed by removing each clause in turn and recompiling.
+ *
+ * <p>One more filename-derived name is at stake here that this module does not control: a transitive
+ * dependency of {@code swagger-parser} (the 1.x-era library it uses internally to convert an OAS 2.0
+ * document) derives the identical automatic module name, {@code swagger.parser}, from its own jar's
+ * filename, and is silently dropped from the module graph as a result - confirmed harmless for OAS
+ * 2.0 conversion specifically (a real Swagger 2.0 corpus document converts and parses correctly end
+ * to end), but a genuine, filename-derived collision nonetheless, and a real ceiling on how cleanly
+ * this module can ever be published as its own, strict JPMS artifact.
+ */
 module io.restest.spec {
     requires io.restest.core;
+    requires swagger.parser;
+    requires swagger.parser.core;
+    requires io.swagger.v3.oas.models;
+    requires org.yaml.snakeyaml;
+
+    exports io.restest.spec;
+
+    provides io.restest.core.spec.SpecificationParser with io.restest.spec.SwaggerSpecificationParser;
 }

--- a/restest-spec/src/test/java/io/restest/spec/MalformedDocumentTest.java
+++ b/restest-spec/src/test/java/io/restest/spec/MalformedDocumentTest.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.spec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restest.core.model.ApiModel;
+import io.restest.core.model.SpecificationIssue;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Documents with one specific, real-world imperfection each: a name a format requires but the
+ * document omits, a reference to a shared definition that is missing or itself unusable, a version
+ * string spelled a little differently than the strictest reading of the format allows. Each is
+ * written directly to a temporary file and read through {@link SwaggerSpecificationParser} end to
+ * end, the same way a real run would - not unit-tested piece by piece - because what matters here is
+ * that the whole pipeline degrades exactly one operation, or reports exactly one document-level
+ * issue, and never anything more than that.
+ */
+class MalformedDocumentTest {
+
+    private final SwaggerSpecificationParser parser = new SwaggerSpecificationParser();
+
+    @Test
+    @DisplayName("a parameter with no name to send it under degrades its operation, not the document")
+    void a_parameter_with_no_name_is_degraded_not_thrown(@TempDir Path dir) throws Exception {
+        ApiModel api = parse(dir, """
+                openapi: 3.0.0
+                info: {title: t, version: '1'}
+                paths:
+                  /widgets:
+                    get:
+                      parameters:
+                        - in: query
+                          schema: {type: string}
+                      responses: {'200': {description: ok}}
+                """);
+
+        // The backend notices the same gap in its own validation pass and reports it too - both are
+        // true at once: its own message, and this class's degraded issue for the operation.
+        assertThat(api.operations()).hasSize(1);
+        assertThat(api.issues())
+                .anySatisfy(issue -> assertThat(issue.effect())
+                        .isEqualTo(SpecificationIssue.Effect.DEGRADED));
+    }
+
+    @Test
+    @DisplayName("a server declaring no URL is dropped, not fatal to reading the rest of the document")
+    void a_server_with_no_url_is_dropped(@TempDir Path dir) throws Exception {
+        ApiModel withNoUrlAtAll = parse(dir, """
+                openapi: 3.0.0
+                info: {title: t, version: '1'}
+                servers:
+                  - description: "no url here"
+                paths: {}
+                """);
+        ApiModel withBlankUrl = parse(dir, """
+                openapi: 3.0.0
+                info: {title: t, version: '1'}
+                servers:
+                  - url: ""
+                paths: {}
+                """);
+
+        assertThat(withNoUrlAtAll.servers()).isEmpty();
+        assertThat(withBlankUrl.servers()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a location that is not even a well-formed URL is reported, not thrown")
+    void a_malformed_url_location_is_reported() {
+        ApiModel api = parser.parse("http://exam ple.com/openapi.yaml");
+
+        assertThat(api.operations()).isEmpty();
+        assertThat(api.issues()).hasSize(1);
+        assertThat(api.issues().get(0).effect()).isEqualTo(SpecificationIssue.Effect.DOCUMENT);
+    }
+
+    @Test
+    @DisplayName("a request body that is a reference to nothing the document declares is reported")
+    void an_unresolved_request_body_reference_is_reported(@TempDir Path dir) throws Exception {
+        ApiModel api = parse(dir, """
+                openapi: 3.0.0
+                info: {title: t, version: '1'}
+                paths:
+                  /widgets:
+                    post:
+                      requestBody:
+                        $ref: '#/components/requestBodies/Missing'
+                      responses: {'200': {description: ok}}
+                """);
+
+        assertThat(api.isComplete()).isFalse();
+        assertThat(api.operation(io.restest.core.model.OperationId.of("POST /widgets"))
+                .orElseThrow().requestBody()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a $ref to a composed schema is degraded, not silently reported complete")
+    void a_reference_to_a_composed_schema_is_degraded(@TempDir Path dir) throws Exception {
+        ApiModel api = parse(dir, """
+                openapi: 3.0.0
+                info: {title: t, version: '1'}
+                paths:
+                  /widgets:
+                    post:
+                      requestBody:
+                        content:
+                          application/json:
+                            schema: {$ref: '#/components/schemas/Pet'}
+                      responses: {'200': {description: ok}}
+                components:
+                  schemas:
+                    Pet:
+                      allOf:
+                        - type: object
+                """);
+
+        // The operation that uses the schema is degraded, not skipped, and the named schema itself
+        // - not tied to any one operation - is named separately: a future consumer that only walks
+        // api.schemas() must be able to see the gap too, not only one reading operation issues.
+        assertThat(api.operations()).hasSize(1);
+        assertThat(api.issues())
+                .anySatisfy(issue -> assertThat(issue.effect())
+                        .isEqualTo(SpecificationIssue.Effect.DEGRADED));
+        assertThat(api.issues())
+                .anySatisfy(issue -> assertThat(issue.location()).contains("Pet"));
+    }
+
+    @Test
+    @DisplayName("an operation-level parameter overrides a path-level $ref of the same name and location")
+    void an_inline_parameter_overrides_a_referenced_path_level_one(@TempDir Path dir) throws Exception {
+        ApiModel api = parse(dir, """
+                openapi: 3.0.0
+                info: {title: t, version: '1'}
+                paths:
+                  /widgets/{id}:
+                    parameters:
+                      - $ref: '#/components/parameters/Id'
+                    get:
+                      parameters:
+                        - name: id
+                          in: path
+                          required: true
+                          schema: {type: integer}
+                      responses: {'200': {description: ok}}
+                components:
+                  parameters:
+                    Id:
+                      name: id
+                      in: path
+                      required: true
+                      schema: {type: string}
+                """);
+
+        assertThat(api.operations()).hasSize(1);
+        assertThat(api.operations().get(0).parameters()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("a plain union of JSON Schema types is degraded, not narrowed to the first type")
+    void a_multi_type_union_is_degraded(@TempDir Path dir) throws Exception {
+        ApiModel api = parse(dir, """
+                openapi: 3.1.0
+                info: {title: t, version: '1'}
+                paths:
+                  /widgets:
+                    get:
+                      responses:
+                        '200':
+                          description: ok
+                          content:
+                            application/json:
+                              schema:
+                                type: [string, integer]
+                """);
+
+        assertThat(api.operations()).hasSize(1);
+        assertThat(api.operations().get(0).responses()).hasSize(1);
+        assertThat(api.issues()).hasSize(1);
+        assertThat(api.issues().get(0).effect()).isEqualTo(SpecificationIssue.Effect.DEGRADED);
+    }
+
+    @Test
+    @DisplayName("one unusable response key costs only that response, not the whole operation")
+    void a_junk_response_key_degrades_only_that_response(@TempDir Path dir) throws Exception {
+        ApiModel api = parse(dir, """
+                openapi: 3.0.0
+                info: {title: t, version: '1'}
+                paths:
+                  /widgets:
+                    get:
+                      responses:
+                        '200 OK': {description: ok}
+                        '200': {description: also ok}
+                """);
+
+        assertThat(api.operations()).hasSize(1);
+        assertThat(api.operations().get(0).responses()).hasSize(1);
+        assertThat(api.issues()).hasSize(1);
+        assertThat(api.issues().get(0).effect()).isEqualTo(SpecificationIssue.Effect.DEGRADED);
+    }
+
+    @Test
+    @DisplayName("a version string with a pre-release tag is accepted, end to end")
+    void a_pre_release_version_tag_is_accepted(@TempDir Path dir) throws Exception {
+        assertThat(parse(dir, "openapi: 3.0.1-rc1\ninfo: {title: t, version: '1'}\npaths: {}\n")
+                .isComplete()).isTrue();
+    }
+
+    @Test
+    @DisplayName("an unquoted or whitespace-padded version is in scope, but the backend still reports its "
+            + "own, stricter check")
+    void a_loosely_spelled_version_is_gated_in_but_reported_by_the_backend(@TempDir Path dir)
+            throws Exception {
+        // YAML reads `3.0` with no quotes as a number, not the string OAS itself requires there, and
+        // the backend's own internal version check does not tolerate the surrounding whitespace in
+        // `' 3.0.1 '` either. The gate is charitable about both - the version either one declares is
+        // unambiguous and in scope - but the backend's own, stricter check still finds the document
+        // malformed once it looks more closely, and reports it. Both things are true at once: not
+        // rejected on a technicality by this class, and not silently accepted as flawless either.
+        ApiModel unquoted = parse(dir, "openapi: 3.0\ninfo: {title: t, version: '1'}\npaths: {}\n");
+        ApiModel padded = parse(dir, "openapi: ' 3.0.1 '\ninfo: {title: t, version: '1'}\npaths: {}\n");
+
+        assertThat(unquoted.isComplete()).isFalse();
+        assertThat(unquoted.issues().get(0).effect()).isEqualTo(SpecificationIssue.Effect.DOCUMENT);
+        assertThat(padded.isComplete()).isFalse();
+        assertThat(padded.issues().get(0).effect()).isEqualTo(SpecificationIssue.Effect.DOCUMENT);
+    }
+
+    @Test
+    @DisplayName("the version gate's own size ceiling is generous, independently of any other limit")
+    void the_version_gate_accepts_a_large_document() {
+        // SnakeYAML's default loader refuses anything past roughly 3,145,728 characters. The gate
+        // raises that ceiling for its own peek; whether the backend it hands off to can also read a
+        // document this large is a separate, unrelated limit this test makes no claim about.
+        String hugeComment = "# " + "x".repeat(4_000_000) + "\n";
+        String document = "openapi: 3.0.0\ninfo:\n  title: t\n  version: '1'\n" + hugeComment;
+
+        assertThat(VersionGate.unsupportedReason(document)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a path-level server is used when the operation itself declares none")
+    void a_path_level_server_is_used_when_the_operation_declares_none(@TempDir Path dir)
+            throws Exception {
+        ApiModel api = parse(dir, """
+                openapi: 3.0.0
+                info: {title: t, version: '1'}
+                paths:
+                  /widgets:
+                    servers:
+                      - url: https://path-specific.example.com
+                    get:
+                      responses: {'200': {description: ok}}
+                """);
+
+        assertThat(api.operations().get(0).servers())
+                .extracting(io.restest.core.model.Server::url)
+                .containsExactly("https://path-specific.example.com");
+    }
+
+    @Test
+    @DisplayName("a response header that is a reference to nothing the document declares is reported")
+    void an_unresolved_header_reference_is_reported(@TempDir Path dir) throws Exception {
+        ApiModel api = parse(dir, """
+                openapi: 3.0.0
+                info: {title: t, version: '1'}
+                paths:
+                  /widgets:
+                    get:
+                      responses:
+                        '200':
+                          description: ok
+                          headers:
+                            X-Rate-Limit:
+                              $ref: '#/components/headers/Missing'
+                """);
+
+        assertThat(api.operations()).hasSize(1);
+        assertThat(api.operations().get(0).responses().get(0).headers()).isEmpty();
+        assertThat(api.issues()).hasSize(1);
+        assertThat(api.issues().get(0).effect()).isEqualTo(SpecificationIssue.Effect.DEGRADED);
+    }
+
+    @Test
+    @DisplayName("a $ref to a $ref is followed to the end of the chain")
+    void a_reference_to_a_reference_is_followed(@TempDir Path dir) throws Exception {
+        ApiModel api = parse(dir, """
+                openapi: 3.0.0
+                info: {title: t, version: '1'}
+                paths:
+                  /widgets/{id}:
+                    get:
+                      parameters:
+                        - $ref: '#/components/parameters/Alias'
+                      responses: {'200': {description: ok}}
+                components:
+                  parameters:
+                    Alias:
+                      $ref: '#/components/parameters/Id'
+                    Id:
+                      name: id
+                      in: path
+                      required: true
+                      schema: {type: string}
+                """);
+
+        assertThat(api.operations()).hasSize(1);
+        assertThat(api.operations().get(0).parameters()).hasSize(1);
+        assertThat(api.issues()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("the backend's own validation messages are reported even when it still returns a document")
+    void backend_validation_messages_are_surfaced(@TempDir Path dir) throws Exception {
+        ApiModel api = parse(dir, """
+                openapi: 3.0.0
+                info: not-an-object
+                paths: {}
+                """);
+
+        assertThat(api.issues()).isNotEmpty();
+        assertThat(api.issues()).allSatisfy(issue ->
+                assertThat(issue.effect()).isEqualTo(SpecificationIssue.Effect.DOCUMENT));
+    }
+
+    @Test
+    @DisplayName("one malformed named schema costs only itself, not every operation in the document")
+    void a_malformed_named_schema_does_not_lose_the_rest_of_the_document(@TempDir Path dir)
+            throws Exception {
+        ApiModel api = parse(dir, """
+                openapi: 3.0.0
+                info: {title: t, version: '1'}
+                paths:
+                  /widgets:
+                    get:
+                      responses: {'200': {description: ok}}
+                components:
+                  schemas:
+                    Broken:
+                      type: string
+                      minLength: 5
+                      maxLength: 2
+                """);
+
+        assertThat(api.operations()).hasSize(1);
+        assertThat(api.schema("Broken")).isPresent();
+        assertThat(api.issues()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("one malformed server variable costs only that server, not every operation in the document")
+    void a_malformed_server_variable_does_not_lose_the_rest_of_the_document(@TempDir Path dir)
+            throws Exception {
+        ApiModel api = parse(dir, """
+                openapi: 3.0.0
+                info: {title: t, version: '1'}
+                servers:
+                  - url: https://{region}.example.com
+                    variables:
+                      region:
+                        enum: [eu, us]
+                        default: ap
+                paths:
+                  /widgets:
+                    get:
+                      responses: {'200': {description: ok}}
+                """);
+
+        assertThat(api.operations()).hasSize(1);
+        assertThat(api.servers()).isEmpty();
+    }
+
+    private ApiModel parse(Path dir, String document) throws Exception {
+        Path file = Files.createTempFile(dir, "openapi", ".yaml");
+        Files.writeString(file, document);
+        return parser.parse(file.toString());
+    }
+}

--- a/restest-spec/src/test/java/io/restest/spec/OperationConverterTest.java
+++ b/restest-spec/src/test/java/io/restest/spec/OperationConverterTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.spec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restest.core.model.HttpMethod;
+import io.restest.core.model.Operation;
+import io.restest.core.model.OperationId;
+import io.restest.core.model.Parameter;
+import io.restest.core.model.ParameterLocation;
+import io.restest.core.model.SpecificationIssue;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter.StyleEnum;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Operation-level conversion, exercised through hand-built {@code swagger-parser} objects rather
+ * than documents, for the same reason as {@link SchemaConverterTest}: fast, and independent of any
+ * fixture's exact text.
+ */
+class OperationConverterTest {
+
+    @Test
+    @DisplayName("an operation's own parameter overrides a path-level one of the same name and location")
+    void operation_parameters_override_path_level_ones() {
+        Schema<Object> pathLevelSchema = new Schema<>();
+        pathLevelSchema.setType("string");
+        io.swagger.v3.oas.models.parameters.Parameter pathLevel =
+                new io.swagger.v3.oas.models.parameters.Parameter()
+                        .name("id").in("query").schema(pathLevelSchema);
+
+        Schema<Object> operationLevelSchema = new Schema<>();
+        operationLevelSchema.setType("integer");
+        io.swagger.v3.oas.models.parameters.Parameter operationLevel =
+                new io.swagger.v3.oas.models.parameters.Parameter()
+                        .name("id").in("query").schema(operationLevelSchema);
+
+        PathItem pathItem = new PathItem().parameters(List.of(pathLevel));
+        pathItem.setGet(new io.swagger.v3.oas.models.Operation()
+                .operationId("getWidget").parameters(List.of(operationLevel)));
+
+        OpenAPI api = apiWithPath("/widgets", pathItem);
+
+        Operation operation = onlyOperation(api);
+
+        assertThat(operation.parameters()).hasSize(1);
+        Parameter parameter = operation.parameter("id", ParameterLocation.QUERY).orElseThrow();
+        assertThat(parameter.schema()).isEqualTo(io.restest.core.schema.NumberSchema.of(
+                io.restest.core.schema.NumberKind.INTEGER));
+    }
+
+    @Test
+    @DisplayName("a duplicate parameter in the same location skips the operation, not the document")
+    void a_duplicate_parameter_skips_only_its_operation() {
+        io.swagger.v3.oas.models.parameters.Parameter first =
+                new io.swagger.v3.oas.models.parameters.Parameter()
+                        .name("id").in("query").schema(new Schema<>().type("string"));
+        io.swagger.v3.oas.models.parameters.Parameter second =
+                new io.swagger.v3.oas.models.parameters.Parameter()
+                        .name("id").in("query").schema(new Schema<>().type("string"));
+
+        PathItem pathItem = new PathItem();
+        pathItem.setGet(new io.swagger.v3.oas.models.Operation()
+                .operationId("getWidget").parameters(List.of(first, second)));
+
+        OpenAPI api = apiWithPath("/widgets", pathItem);
+        OperationConverter.Result result = OperationConverter.convert(api, java.util.Map.of());
+
+        assertThat(result.operations()).isEmpty();
+        assertThat(result.issues()).hasSize(1);
+        SpecificationIssue issue = result.issues().get(0);
+        assertThat(issue.skipsAnOperation()).isTrue();
+        assertThat(issue.operation()).contains(OperationId.of("getWidget"));
+    }
+
+    @Test
+    @DisplayName("a path template with nothing to fill one of its variables skips the operation")
+    void an_unfillable_template_skips_the_operation() {
+        PathItem pathItem = new PathItem();
+        pathItem.setGet(new io.swagger.v3.oas.models.Operation().operationId("getWidget"));
+
+        OpenAPI api = apiWithPath("/widgets/{widgetId}", pathItem);
+        OperationConverter.Result result = OperationConverter.convert(api, java.util.Map.of());
+
+        assertThat(result.operations()).isEmpty();
+        assertThat(result.issues()).hasSize(1);
+        assertThat(result.issues().get(0).skipsAnOperation()).isTrue();
+    }
+
+    @Test
+    @DisplayName("a required request body declaring no media type skips the operation")
+    void a_required_body_with_no_content_skips_the_operation() {
+        PathItem pathItem = new PathItem();
+        pathItem.setPost(new io.swagger.v3.oas.models.Operation().operationId("createWidget")
+                .requestBody(new RequestBody().required(true)));
+
+        OpenAPI api = apiWithPath("/widgets", pathItem);
+        OperationConverter.Result result = OperationConverter.convert(api, java.util.Map.of());
+
+        assertThat(result.operations()).isEmpty();
+        assertThat(result.issues()).hasSize(1);
+        assertThat(result.issues().get(0).skipsAnOperation()).isTrue();
+    }
+
+    @Test
+    @DisplayName("two operations sharing one operationId keep both operations, the second renamed")
+    void a_duplicate_operation_id_is_disambiguated_not_dropped() {
+        PathItem widgets = new PathItem();
+        widgets.setGet(new io.swagger.v3.oas.models.Operation().operationId("list"));
+        PathItem gadgets = new PathItem();
+        gadgets.setGet(new io.swagger.v3.oas.models.Operation().operationId("list"));
+
+        Paths paths = new Paths();
+        paths.addPathItem("/widgets", widgets);
+        paths.addPathItem("/gadgets", gadgets);
+        OpenAPI api = new OpenAPI().paths(paths);
+
+        OperationConverter.Result result = OperationConverter.convert(api, java.util.Map.of());
+
+        assertThat(result.operations()).hasSize(2);
+        assertThat(result.operations().stream().map(Operation::id).distinct()).hasSize(2);
+        assertThat(result.operations().stream().map(Operation::id))
+                .contains(OperationId.of("list"));
+        assertThat(result.issues()).hasSize(1);
+        assertThat(result.issues().get(0).effect())
+                .isEqualTo(SpecificationIssue.Effect.DEGRADED);
+    }
+
+    @Test
+    @DisplayName("a media-type-serialised parameter is read by its content, not a style")
+    void a_content_serialised_parameter_carries_its_media_type() {
+        Schema<Object> filterSchema = new Schema<>();
+        filterSchema.setType("object");
+        MediaType mediaType = new MediaType().schema(filterSchema);
+        Content content = new Content();
+        content.addMediaType("application/json", mediaType);
+        io.swagger.v3.oas.models.parameters.Parameter parameter =
+                new io.swagger.v3.oas.models.parameters.Parameter()
+                        .name("filter").in("query").content(content);
+
+        PathItem pathItem = new PathItem();
+        pathItem.setGet(new io.swagger.v3.oas.models.Operation()
+                .operationId("search").parameters(List.of(parameter)));
+
+        Operation operation = onlyOperation(apiWithPath("/widgets", pathItem));
+
+        Parameter converted = operation.parameter("filter", ParameterLocation.QUERY).orElseThrow();
+        assertThat(converted.isContentSerialised()).isTrue();
+        assertThat(converted.mediaType()).contains("application/json");
+    }
+
+    @Test
+    @DisplayName("a declared style is translated to its RESTest equivalent")
+    void a_declared_style_is_translated() {
+        io.swagger.v3.oas.models.parameters.Parameter parameter =
+                new io.swagger.v3.oas.models.parameters.Parameter()
+                        .name("tags").in("query").schema(new Schema<>().type("string"))
+                        .style(StyleEnum.PIPEDELIMITED);
+
+        PathItem pathItem = new PathItem();
+        pathItem.setGet(new io.swagger.v3.oas.models.Operation()
+                .operationId("list").parameters(List.of(parameter)));
+
+        Operation operation = onlyOperation(apiWithPath("/widgets", pathItem));
+
+        assertThat(operation.parameter("tags", ParameterLocation.QUERY).orElseThrow().style())
+                .isEqualTo(io.restest.core.model.ParameterStyle.PIPE_DELIMITED);
+    }
+
+    @Test
+    @DisplayName("a parameter declaring no style at all falls back to the location's default")
+    void no_declared_style_falls_back_to_the_locations_default() {
+        io.swagger.v3.oas.models.parameters.Parameter parameter =
+                new io.swagger.v3.oas.models.parameters.Parameter()
+                        .name("tags").in("query").schema(new Schema<>().type("string"));
+
+        PathItem pathItem = new PathItem();
+        pathItem.setGet(new io.swagger.v3.oas.models.Operation()
+                .operationId("list").parameters(List.of(parameter)));
+
+        Operation operation = onlyOperation(apiWithPath("/widgets", pathItem));
+
+        assertThat(operation.parameter("tags", ParameterLocation.QUERY).orElseThrow().style())
+                .isEqualTo(io.restest.core.model.ParameterStyle.defaultFor(ParameterLocation.QUERY));
+    }
+
+    private static OpenAPI apiWithPath(String path, PathItem pathItem) {
+        Paths paths = new Paths();
+        paths.addPathItem(path, pathItem);
+        return new OpenAPI().paths(paths);
+    }
+
+    private static Operation onlyOperation(OpenAPI api) {
+        OperationConverter.Result result = OperationConverter.convert(api, java.util.Map.of());
+        assertThat(result.operations()).hasSize(1);
+        assertThat(result.issues()).isEmpty();
+        return result.operations().get(0);
+    }
+}

--- a/restest-spec/src/test/java/io/restest/spec/SchemaConverterTest.java
+++ b/restest-spec/src/test/java/io/restest/spec/SchemaConverterTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.spec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restest.core.schema.AnySchema;
+import io.restest.core.schema.ArraySchema;
+import io.restest.core.schema.BooleanSchema;
+import io.restest.core.schema.CanonicalSchema;
+import io.restest.core.schema.NothingSchema;
+import io.restest.core.schema.NumberKind;
+import io.restest.core.schema.NumberSchema;
+import io.restest.core.schema.ObjectSchema;
+import io.restest.core.schema.SchemaMetadata;
+import io.restest.core.schema.SchemaReference;
+import io.restest.core.schema.StringSchema;
+import io.restest.core.schema.UnsupportedSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * One case per canonical shape {@link SchemaConverter} must produce, plus the 3.0-to-3.1 differences
+ * that fail silently rather than loudly if read the wrong way. Built directly against hand-constructed
+ * {@code swagger-parser} schema objects, not documents, so these stay fast and pin exact behaviour
+ * independent of any fixture.
+ */
+class SchemaConverterTest {
+
+    @Test
+    @DisplayName("a string schema carries its length, pattern and format constraints")
+    void a_string_type_becomes_a_string_schema() {
+        Schema<Object> schema = new Schema<>();
+        schema.setType("string");
+        schema.setMinLength(1);
+        schema.setMaxLength(10);
+        schema.setPattern("^[a-z]+$");
+        schema.setFormat("email");
+
+        CanonicalSchema converted = SchemaConverter.convert(schema);
+
+        assertThat(converted).isInstanceOf(StringSchema.class);
+        StringSchema string = (StringSchema) converted;
+        assertThat(string.minLength()).contains(1);
+        assertThat(string.maxLength()).contains(10);
+        assertThat(string.pattern()).contains("^[a-z]+$");
+        assertThat(string.format()).contains("email");
+    }
+
+    @Test
+    @DisplayName("'integer' and 'number' are one record, distinguished by kind")
+    void integer_and_number_become_number_schema_with_the_right_kind() {
+        Schema<Object> integer = new Schema<>();
+        integer.setType("integer");
+        Schema<Object> number = new Schema<>();
+        number.setType("number");
+
+        assertThat(((NumberSchema) SchemaConverter.convert(integer)).kind()).isEqualTo(NumberKind.INTEGER);
+        assertThat(((NumberSchema) SchemaConverter.convert(number)).kind()).isEqualTo(NumberKind.NUMBER);
+    }
+
+    @Test
+    @DisplayName("a boolean schema has nothing to constrain beyond its type")
+    void a_boolean_type_becomes_a_boolean_schema() {
+        Schema<Object> schema = new Schema<>();
+        schema.setType("boolean");
+
+        assertThat(SchemaConverter.convert(schema)).isInstanceOf(BooleanSchema.class);
+    }
+
+    @Test
+    @DisplayName("an object schema carries its properties and required names")
+    void an_object_type_becomes_an_object_schema() {
+        Schema<Object> name = new Schema<>();
+        name.setType("string");
+        Schema<Object> schema = new Schema<>();
+        schema.setType("object");
+        schema.setProperties(Map.of("name", name));
+        schema.setRequired(List.of("name"));
+
+        CanonicalSchema converted = SchemaConverter.convert(schema);
+
+        assertThat(converted).isInstanceOf(ObjectSchema.class);
+        ObjectSchema object = (ObjectSchema) converted;
+        assertThat(object.property("name")).contains(StringSchema.of());
+        assertThat(object.isRequired("name")).isTrue();
+    }
+
+    @Test
+    @DisplayName("additionalProperties: false is NothingSchema, not a failure to read the document")
+    void additional_properties_false_becomes_nothing_schema() {
+        Schema<Object> schema = new Schema<>();
+        schema.setType("object");
+        schema.setAdditionalProperties(Boolean.FALSE);
+
+        ObjectSchema object = (ObjectSchema) SchemaConverter.convert(schema);
+
+        assertThat(object.isClosed()).isTrue();
+        assertThat(object.additionalProperties()).contains(NothingSchema.of());
+    }
+
+    @Test
+    @DisplayName("an array schema carries the one shape every element has")
+    void an_array_type_becomes_an_array_schema() {
+        Schema<Object> items = new Schema<>();
+        items.setType("string");
+        Schema<Object> schema = new Schema<>();
+        schema.setType("array");
+        schema.setItems(items);
+        schema.setMinItems(1);
+        schema.setUniqueItems(true);
+
+        CanonicalSchema converted = SchemaConverter.convert(schema);
+
+        assertThat(converted).isInstanceOf(ArraySchema.class);
+        ArraySchema array = (ArraySchema) converted;
+        assertThat(array.items()).isEqualTo(StringSchema.of());
+        assertThat(array.minItems()).contains(1);
+        assertThat(array.uniqueItems()).isTrue();
+    }
+
+    @Test
+    @DisplayName("no declared type and no structural hint is AnySchema: any value will do")
+    void no_type_becomes_any_schema() {
+        Schema<Object> schema = new Schema<>();
+
+        assertThat(SchemaConverter.convert(schema)).isEqualTo(AnySchema.of());
+    }
+
+    @Test
+    @DisplayName("a $ref stays a lazy reference, never inlined")
+    void a_ref_becomes_a_schema_reference() {
+        Schema<Object> schema = new Schema<>();
+        schema.set$ref("#/components/schemas/Pet");
+
+        CanonicalSchema converted = SchemaConverter.convert(schema);
+
+        assertThat(converted).isEqualTo(SchemaReference.to("Pet"));
+    }
+
+    @Test
+    @DisplayName("oneOf/anyOf/allOf composition is not yet folded, deliberately, until increment 2.1")
+    void composition_becomes_unsupported() {
+        Schema<Object> option = new Schema<>();
+        option.setType("string");
+
+        Schema<Object> oneOf = new Schema<>();
+        oneOf.setOneOf(List.of(option));
+        Schema<Object> anyOf = new Schema<>();
+        anyOf.setAnyOf(List.of(option));
+        Schema<Object> allOf = new Schema<>();
+        allOf.setAllOf(List.of(option));
+
+        assertThat(SchemaConverter.convert(oneOf)).isInstanceOf(UnsupportedSchema.class);
+        assertThat(SchemaConverter.convert(anyOf)).isInstanceOf(UnsupportedSchema.class);
+        assertThat(SchemaConverter.convert(allOf)).isInstanceOf(UnsupportedSchema.class);
+    }
+
+    @Test
+    @DisplayName("a tuple-form array, where every element has its own shape, is not representable")
+    void a_tuple_form_array_becomes_unsupported() {
+        Schema<Object> first = new Schema<>();
+        first.setType("string");
+        Schema<Object> second = new Schema<>();
+        second.setType("integer");
+        Schema<Object> schema = new Schema<>();
+        schema.setType("array");
+        schema.setPrefixItems(List.of(first, second));
+
+        assertThat(SchemaConverter.convert(schema)).isInstanceOf(UnsupportedSchema.class);
+    }
+
+    @Test
+    @DisplayName("OAS 3.0: nullable is a sibling boolean keyword")
+    void nullable_as_a_3_0_boolean_is_read() {
+        Schema<Object> schema = new Schema<>();
+        schema.setType("string");
+        schema.setNullable(true);
+
+        assertThat(SchemaConverter.convert(schema).metadata().nullable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("OAS 3.1: nullable is a member of a JSON Schema type array, not a sibling keyword")
+    void nullable_as_a_3_1_type_array_is_read() {
+        Schema<Object> schema = new Schema<>();
+        schema.setTypes(Set.of("string", "null"));
+
+        CanonicalSchema converted = SchemaConverter.convert(schema);
+
+        assertThat(converted).isInstanceOf(StringSchema.class);
+        assertThat(converted.metadata().nullable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("OAS 3.0: exclusiveMinimum is a flag next to minimum, not a bound of its own")
+    void exclusive_minimum_as_a_3_0_boolean_moves_the_bound() {
+        Schema<Object> schema = new Schema<>();
+        schema.setType("number");
+        schema.setMinimum(BigDecimal.valueOf(5));
+        schema.setExclusiveMinimum(true);
+
+        NumberSchema number = (NumberSchema) SchemaConverter.convert(schema);
+
+        assertThat(number.minimum()).isEmpty();
+        assertThat(number.exclusiveMinimum()).contains(BigDecimal.valueOf(5));
+    }
+
+    @Test
+    @DisplayName("OAS 3.1: exclusiveMinimum is itself the numeric bound (JSON Schema 2020-12)")
+    void exclusive_minimum_as_a_3_1_number_is_read_directly() {
+        Schema<Object> schema = new Schema<>();
+        schema.setType("number");
+        schema.setExclusiveMinimumValue(BigDecimal.ZERO);
+
+        NumberSchema number = (NumberSchema) SchemaConverter.convert(schema);
+
+        assertThat(number.minimum()).isEmpty();
+        assertThat(number.exclusiveMinimum()).contains(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("readOnly and writeOnly become one Access, never both at once")
+    void read_only_and_write_only_become_access() {
+        Schema<Object> readOnly = new Schema<>();
+        readOnly.setType("string");
+        readOnly.setReadOnly(true);
+        Schema<Object> writeOnly = new Schema<>();
+        writeOnly.setType("string");
+        writeOnly.setWriteOnly(true);
+
+        assertThat(SchemaConverter.convert(readOnly).metadata().access())
+                .isEqualTo(SchemaMetadata.Access.READ_ONLY);
+        assertThat(SchemaConverter.convert(writeOnly).metadata().access())
+                .isEqualTo(SchemaMetadata.Access.WRITE_ONLY);
+    }
+
+    @Test
+    @DisplayName("hasUnsupportedConstruct finds an unsupported shape nested inside an object or array")
+    void unsupported_constructs_are_found_when_nested() {
+        Schema<Object> composed = new Schema<>();
+        composed.setOneOf(List.of(new Schema<>()));
+        Schema<Object> nestedInObject = new Schema<>();
+        nestedInObject.setType("object");
+        nestedInObject.setProperties(Map.of("bad", composed));
+        Schema<Object> nestedInArray = new Schema<>();
+        nestedInArray.setType("array");
+        nestedInArray.setItems(composed);
+        Schema<Object> clean = new Schema<>();
+        clean.setType("string");
+
+        assertThat(SchemaConverter.hasUnsupportedConstruct(SchemaConverter.convert(nestedInObject))).isTrue();
+        assertThat(SchemaConverter.hasUnsupportedConstruct(SchemaConverter.convert(nestedInArray))).isTrue();
+        assertThat(SchemaConverter.hasUnsupportedConstruct(SchemaConverter.convert(clean))).isFalse();
+    }
+}

--- a/restest-spec/src/test/java/io/restest/spec/SwaggerSpecificationParserTest.java
+++ b/restest-spec/src/test/java/io/restest/spec/SwaggerSpecificationParserTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.spec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restest.core.model.ApiModel;
+import io.restest.core.model.HttpMethod;
+import io.restest.core.model.Operation;
+import io.restest.core.model.OperationId;
+import io.restest.core.model.SpecificationIssue;
+import io.restest.core.schema.CanonicalSchema;
+import io.restest.core.schema.NumberSchema;
+import io.restest.core.schema.SchemaReference;
+import io.restest.core.schema.StringSchema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives {@link SwaggerSpecificationParser} through real documents: the priority corpus, a 2.0
+ * document converted rather than parsed directly, the 3.1 traps, and the hand-written fixtures for
+ * what a real document in this corpus was not found to exercise cleanly on its own.
+ */
+class SwaggerSpecificationParserTest {
+
+    private final SwaggerSpecificationParser parser = new SwaggerSpecificationParser();
+
+    @Test
+    @DisplayName("a plain OAS 3.0.x document from the priority corpus reads without crashing")
+    void a_3_0_document_from_the_priority_corpus_reads_without_crashing() {
+        ApiModel api = parser.parse("specifications/restleague-2027/pet-clinic/openapi.yaml");
+
+        assertThat(api.operations()).isNotEmpty();
+        assertThat(api.title()).isNotBlank();
+        // Every operation stays present and testable; the schema composition this increment does not
+        // fold (see SchemaConverter) is reported, never skipped - once against the named schema that
+        // actually uses it, and again, DEGRADED rather than DOCUMENT, against every operation whose
+        // data reaches that schema.
+        assertThat(api.issues()).isNotEmpty();
+        assertThat(api.issues())
+                .noneSatisfy(issue -> assertThat(issue.effect())
+                        .isEqualTo(SpecificationIssue.Effect.OPERATION_SKIPPED));
+        assertThat(api.issues())
+                .anySatisfy(issue -> assertThat(issue.effect())
+                        .isEqualTo(SpecificationIssue.Effect.DEGRADED));
+    }
+
+    @Test
+    @DisplayName("a Swagger 2.0 document converts to the same shape a native 3.x document would have")
+    void a_2_0_document_converts_cleanly() {
+        ApiModel api = parser.parse("specifications/community/Petstore/openapi.yaml");
+
+        assertThat(api.operations()).isNotEmpty();
+        Operation addPet = api.operation(OperationId.of("addPet")).orElseThrow();
+        assertThat(addPet.method()).isEqualTo(HttpMethod.POST);
+        // OpenAPI 2.0's `in: body` became a RequestBodyModel - no BODY/FORM_DATA parameter location
+        // exists in this model at all, so this is only possible if the conversion actually happened.
+        assertThat(addPet.requestBody()).isPresent();
+        assertThat(addPet.requestBody().orElseThrow().required()).isTrue();
+        CanonicalSchema body = addPet.requestBody().orElseThrow().schemaFor("application/json")
+                .orElseThrow();
+        assertThat(body).isEqualTo(SchemaReference.to("Pet"));
+    }
+
+    @Test
+    @DisplayName("OAS 3.1's nullable-as-type-array and numeric exclusiveMinimum are both read correctly")
+    void oas_3_1_traps_are_read_correctly() {
+        ApiModel api = parser.parse("specifications/fixtures/oas31-traps/openapi.yaml");
+
+        assertThat(api.isComplete()).isTrue();
+        CanonicalSchema account = api.schema("Account").orElseThrow();
+        assertThat(account).isInstanceOf(io.restest.core.schema.ObjectSchema.class);
+        io.restest.core.schema.ObjectSchema accountSchema = (io.restest.core.schema.ObjectSchema) account;
+
+        StringSchema displayName = (StringSchema) accountSchema.property("displayName").orElseThrow();
+        assertThat(displayName.metadata().nullable()).isTrue();
+
+        NumberSchema balance = (NumberSchema) accountSchema.property("balance").orElseThrow();
+        assertThat(balance.exclusiveMinimum()).contains(java.math.BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("a dangling $ref degrades gracefully by the model's own design, not special parser handling")
+    void a_dangling_reference_resolves_to_empty_without_crashing() {
+        ApiModel api = parser.parse("specifications/fixtures/malformed/openapi.yaml");
+
+        Operation attachGadget = api.operation(OperationId.of("attachGadget")).orElseThrow();
+        CanonicalSchema requestSchema = attachGadget.requestBody().orElseThrow()
+                .schemaFor("application/json").orElseThrow();
+        assertThat(requestSchema).isEqualTo(SchemaReference.to("Gadget"));
+        assertThat(api.resolve((SchemaReference) requestSchema)).isEmpty();
+        // The operation with the dangling reference is still present and testable - not skipped.
+        assertThat(api.operation(OperationId.of("listWidgets"))).isPresent();
+    }
+
+    @Test
+    @DisplayName("an OAS 3.2 document is reported as unsupported, in its own words, rather than parsed")
+    void an_unsupported_version_is_reported_not_parsed() {
+        ApiModel api = parser.parse("specifications/fixtures/unsupported-version/openapi.yaml");
+
+        assertThat(api.operations()).isEmpty();
+        assertThat(api.issues()).hasSize(1);
+        SpecificationIssue issue = api.issues().get(0);
+        assertThat(issue.effect()).isEqualTo(SpecificationIssue.Effect.DOCUMENT);
+        assertThat(issue.message()).contains("3.2");
+    }
+
+    @Test
+    @DisplayName("a document that is not valid YAML at all is reported, never thrown")
+    void an_unparseable_document_is_reported_not_thrown() {
+        ApiModel api = parser.parse("specifications/fixtures/unparseable/openapi.yaml");
+
+        assertThat(api.operations()).isEmpty();
+        assertThat(api.issues()).hasSize(1);
+        assertThat(api.issues().get(0).effect()).isEqualTo(SpecificationIssue.Effect.DOCUMENT);
+    }
+
+    @Test
+    @DisplayName("a location nothing answers at is reported, never thrown and never silent")
+    void a_missing_location_is_reported_not_thrown() {
+        ApiModel api = parser.parse("specifications/does/not/exist.yaml");
+
+        assertThat(api.operations()).isEmpty();
+        assertThat(api.issues()).hasSize(1);
+        assertThat(api.issues().get(0).effect()).isEqualTo(SpecificationIssue.Effect.DOCUMENT);
+    }
+}

--- a/restest-spec/src/test/resources/specifications/README.md
+++ b/restest-spec/src/test/resources/specifications/README.md
@@ -47,11 +47,14 @@ that no single real-world document in `community/` was found to exercise cleanly
 - `oas31-traps/openapi.yaml` — the 3.0-to-3.1 differences ADR-0007 names as silent traps: `nullable`
   as a JSON Schema type-array member instead of a sibling keyword, and a numeric `exclusiveMinimum`
   instead of a boolean flag.
+- `unparseable/openapi.yaml` — not valid YAML at all (an unclosed flow mapping). For the loader-level
+  failure that happens *before* per-operation skipping is even reachable: a document that never
+  becomes an `OpenAPI` object at all, as distinct from one that parses fine but has a malformed
+  operation in it.
 
-Each file says so in its own `info.description`. `CorpusSanityTest`, alongside this directory, pins
-the properties this README and ADR-0007 claim about the corpus as a whole (every file declares a
-version; exactly one declares 3.2; the malformed fixture's reference stays dangling) — as plain-text
-checks, since no `SpecificationParser` exists yet to check them any other way. It deliberately does
-not cover documents that are not even valid YAML/JSON, or that omit `openapi`/`info` entirely: those
-are a loader-level concern for whoever builds `SpecificationParser`, and belong with that increment's
-own tests, once that increment has decided how the loader should fail.
+Each file says so in its own `info.description` (`unparseable/` cannot, since it never parses far
+enough to have one — its own comment says so instead). `CorpusSanityTest`, alongside this directory,
+pins the properties this README claims about the corpus as a whole (every file declares a version;
+exactly one declares 3.2; the malformed fixture's reference stays dangling) — as plain-text checks,
+independent of `SpecificationParser` itself, which has its own, much more thorough test suite in
+`restest-spec/src/test/java/io/restest/spec/` covering exactly these fixtures end to end.

--- a/restest-spec/src/test/resources/specifications/fixtures/unparseable/openapi.yaml
+++ b/restest-spec/src/test/resources/specifications/fixtures/unparseable/openapi.yaml
@@ -1,0 +1,12 @@
+# Hand-written for this corpus, not carried over from any real API. Deliberately not valid YAML: the
+# flow mapping opened on the last line is never closed. For the loader-level failure that happens
+# before per-operation skipping is even reachable - see the sibling fixtures/malformed/ for that case.
+openapi: 3.0.0
+info:
+  title: Fixture - not valid YAML
+  version: "1.0"
+paths:
+  /widgets:
+    get:
+      responses:
+        "200": {description: "the flow mapping on this line is never closed


### PR DESCRIPTION
**Increment:** 1.2, from ROADMAP.md

## What you can do now that you could not before

The tool can read a real OpenAPI or Swagger document and turn it into RESTest's own model without
crashing, whatever is wrong with it. Point it at any of the five 2027 REST League APIs, or at any of
the ~40 other real-world specifications already in the golden corpus, and every operation the document
declares comes back as a first-class, testable `Operation` — a duplicate parameter, a broken
`$ref`, an unfillable path template, an unrecognised schema construct each degrade just the one thing
they touch, never the whole run. Nothing downstream exists yet to *use* this (test generation is
increment 1.5 onward), so there is still no visible end-to-end run — but the wall this project failed
against before (a bad specification simply crashing the tool) is gone.

## Try it yourself

    git fetch && git switch feat/m1-2-specification-parser
    ./mvnw test -pl restest-spec -am

Expected (real output, trimmed to this module's own tests):

    [INFO] Running io.restest.spec.CorpusSanityTest
    [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.115 s -- in io.restest.spec.CorpusSanityTest
    [INFO] Running io.restest.spec.SchemaConverterTest
    [INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s -- in io.restest.spec.SchemaConverterTest
    [INFO] Running io.restest.spec.SwaggerSpecificationParserTest
    [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.596 s -- in io.restest.spec.SwaggerSpecificationParserTest
    [INFO] Running io.restest.spec.MalformedDocumentTest
    [INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.203 s -- in io.restest.spec.MalformedDocumentTest
    [INFO] Running io.restest.spec.OperationConverterTest
    [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in io.restest.spec.OperationConverterTest
    [INFO] BUILD SUCCESS

No command-line entry point exists yet (that is increment 1.7), so this is the closest thing to
running it today. `SwaggerSpecificationParserTest` and `MalformedDocumentTest` are the ones worth
opening: the first parses real corpus files (a genuine Swagger 2.0 Petstore document, the 3.1-traps
fixture, the priority corpus), the second writes small, deliberately broken documents to a temp file
and asserts exactly what degrades and what does not.

## How it works

An OpenAPI or Swagger document goes through three steps before it becomes an `ApiModel`. First, a
**version gate** reads the document's own declared `openapi`/`swagger` key directly — before handing
anything to the actual parsing library — because that library does not fail cleanly on a version it
does not support: fed `openapi: 3.2.0` it returned confusing messages that never mentioned 3.2, and a
result that silently claimed a different version. Only 2.0 (converted to 3.0 automatically), 3.0.x and
3.1.x get past the gate; anything else is reported and never parsed.

Second, **schema conversion** turns whatever shape a field, parameter or body describes into one of
ten canonical kinds RESTest works with everywhere else, so nothing downstream ever has to know which
OpenAPI version, or which of several equivalent spellings, a document used. The best example is
"nullable": OpenAPI 3.0 writes `nullable: true` as a sibling keyword, OpenAPI 3.1 writes
`type: [string, "null"]` instead — both are read into the exact same fact. A schema declared as "one
of several possible shapes" (a common way to model inheritance or polymorphism) is not folded into
this model yet — that is the next increment — so it is marked, honestly, as not-yet-understood rather
than silently narrowed to something wrong.

Third, **operation conversion** walks every path and turns it into `Operation`s. This is where most of
the real-world messiness lives: a parameter can be declared once for a whole path and then overridden
by one specific operation; a parameter, request body, response or header can be a reference to a
shared definition declared elsewhere, sometimes several hops removed; a document can have two
operations that accidentally share the same identifier. Each of these is handled explicitly rather than
allowed to crash the conversion, and reported at exactly the scope it costs: one dropped response, one
degraded operation, or — as a last resort, for whatever this class did not think to name specifically —
one document-level note, never the loss of the whole document over one bad corner of it.

## What changed in the code

- `restest-core/.../spec/SpecificationParser.java` — the new interface, `ApiModel parse(String
  location)`. Never throws for a problem with the document; unreadable location, invalid YAML/JSON, an
  unsupported version, a malformed operation all become an `ApiModel` with issues attached, using the
  `SpecificationIssue` factories already in the model.
- `restest-spec/.../VersionGate.java` — the version check described above, via a direct `snakeyaml`
  load (now an explicit, pinned dependency, not left to whatever version `swagger-parser` happens to
  pull in transitively). Its size and nesting-depth ceilings are both raised well past SnakeYAML's
  defaults, which were tight enough to reject a real, valid, if unusually large or deeply nested,
  document.
- `restest-spec/.../SchemaConverter.java` — the ten-kind conversion, including both OAS versions'
  spellings of nullability and exclusive bounds, and detection of the two shapes this increment
  deliberately does not fold: composition (`oneOf`/`anyOf`/`allOf`/`not`/discriminators) and plain JSON
  Schema type unions (`type: [string, integer]`, distinct from the nullable idiom). A schema reached
  only through a `$ref` is checked too, one level at a time with a cycle guard, so a reference to a
  composed schema is not silently reported as fine.
- `restest-spec/.../OperationConverter.java` — parameter merge and override, `$ref` resolution
  (parameters, request bodies, responses, headers — each following a whole chain of references, not
  just one hop), and the per-construct fault tolerance described above. `SpecificationParser`'s
  "never crash" contract is enforced at several different granularities on purpose: a bad response
  costs one response, a bad operation costs one operation, a bad named schema or server costs only
  itself, and only a genuine surprise reaches the top-level backstop in `SwaggerSpecificationParser`.
- `restest-spec/.../SwaggerSpecificationParser.java` — the public implementation. Reads the location
  (file path, classpath resource, or URL, with a timeout and a size cap on the last), runs the gate,
  delegates to `swagger-parser`, and surfaces its own validation messages even when it still returns a
  document (previously only surfaced when it returned nothing at all — a structurally broken document
  used to come back reporting nothing wrong).
- `restest-spec/pom.xml`, `module-info.java` (both modules) — `swagger-parser` and `snakeyaml` as
  explicit, pinned dependencies; `restest-spec` now exports `io.restest.spec` and declares (unused as
  yet) `provides ... with SwaggerSpecificationParser`, so a future `ServiceLoader`-based consumer has
  nothing to add here when it arrives.
- One new hand-written fixture, `fixtures/unparseable/` (genuinely invalid YAML), filling the one gap
  the corpus's own README had flagged as deliberately left for this increment.

Deliberately left for later increments: folding `oneOf`/`anyOf`/`allOf` into the canonical model
(2.1), declared examples (2.2), anything about generating or sending a request at all.

## Evidence

- [x] Tests: 51 added in `restest-spec` (all green); 197 pre-existing in `restest-core` untouched and
  still green (248 total) — CI not yet run, branch just pushed.
- [x] Architecture tests: unchanged in count (18, all passing) — `only restest-spec references the
  swagger parser` still holds with the new dependency.
- [ ] Mutation score: n/a, no oracle or constraint code touched.
- [ ] Per-request overhead: n/a, no request path exists yet.
- [ ] Smoke run: n/a, no `restest-cli` behaviour exists yet.
- [ ] Idle time: n/a.
- [x] Artefact: a full sweep of every document in the golden corpus (all 50 files across `community/`,
  `restleague-2027/` and `fixtures/`) — zero crashes. The largest real document, `community/GitHub`
  (473 paths, 743 operations), reads in full; the priority-corpus `pet-clinic` document reads with 35
  operations and 34 degraded issues, all naming a schema-composition construct this increment does not
  fold yet, never a skip.

## Decisions taken

- **Went through two full review rounds before opening this PR**, each followed by concrete fixes and
  new regression tests, because the first pass alone would have shipped real crash bugs (a parameter
  with no name, a server with no URL, a malformed URL location all threw) and real silent data loss
  (three of the four `$ref` kinds, and any schema reached only through a reference to a composed one,
  both passed as `isComplete() == true` when they should not have). The second pass found gaps in the
  first round's own fixes — this is reported for transparency, not as a claim that a third pass would
  find nothing; the corpus sweep and the test suite are what this PR actually stands on, not the review
  process itself.
- **A single, hand-rolled `SnakeYAML` peek decides the version, rather than trusting the parsing
  library's own signal.** More code than trusting the library, but the library was empirically wrong
  in a way that mattered: for a 3.2 document it silently claimed a different version rather than
  reporting the mismatch.
- **`$ref` chains are followed fully (with a cycle guard) for parameters, request bodies, responses
  and headers, but schema references stay lazy** (one level of composition-checking, not full
  resolution) — reusable non-schema components are a flat lookup with no risk of the unbounded
  recursion a schema `$ref` graph can have, so there is no reason to stop at one hop for those; schemas
  keep the lazy design the canonical model (`SchemaReference`) already commits to.
- **A named schema unsupported by this increment is reported twice when an operation also uses it**
  (once against the schema itself, once as a degraded operation) — accepted as useful redundancy, not
  fixed to report only once, because a future reader who only walks `ApiModel.schemas()` without
  reading operation issues still needs to see the gap.
- **Did not fix the automatic-module-name collision between `swagger-parser`'s own jar and a legacy
  1.x-era jar it pulls in transitively for OAS 2.0 conversion** (both derive the filename-based name
  `swagger.parser`; one is silently dropped from the module graph). Confirmed harmless for 2.0
  conversion specifically — a real Swagger 2.0 document converts and parses correctly end to end — but
  it is a genuine ceiling on how cleanly `restest-spec` can ever be published as a strict JPMS artifact
  for Maven Central (M7.1). Documented in `module-info.java`'s own Javadoc rather than worked around;
  resolving it would mean either excluding the transitive 1.x dependency (risky without knowing exactly
  what it's needed for) or moving off `swagger-parser` entirely, neither of which belongs in this
  increment.
- **Did not implement `ServiceLoader`-based discovery of `SpecificationParser`** — the `provides`
  clause is declared, but nothing calls `ServiceLoader.load` yet and no consumer declares `uses`. That
  is `restest-cli`'s job (1.7) or later.

## Open questions

Whether the automatic-module-name collision above (item under "Decisions taken") needs to be resolved
before M7.1, or whether it is acceptable to defer until packaging work actually starts — no action
needed now either way, just flagging it while it's fresh.

---

- [x] Targets `v2`, not `main`
- [x] English throughout, including comments and test names
- [x] Nothing from the deferred backlog ("Out of scope for v2.0" in `docs/DESIGN.md`)
- [x] No AI abstraction; no benchmark-platform reference under `src/`
- [x] Reviewed by the `reviewer` subagent
