### PR TITLE
Keep every run in one file, and ask it questions afterwards

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ its own pull request, so the table and the branch history never drift apart.
 | 1.1b ✅ [#285](https://github.com/isa-group/RESTest/pull/285) | Execution model: `TestCase`, value provenance, exact request and response payloads, `Interaction` and its outcome | A representation of what we did to the API, and what came back |
 | 1.2 ✅ [#287](https://github.com/isa-group/RESTest/pull/287), [#289](https://github.com/isa-group/RESTest/pull/289) | `SpecificationParser` interface + a single swagger-parser backend; OAS 2.0 (by conversion), 3.0.x and 3.1.x; lazy `$ref`; malformed operations, and any OAS 3.2 (or later) document, skipped and reported rather than failing the run | Point the tool at any real specification without it crashing |
 | 1.3 ✅ [#290](https://github.com/isa-group/RESTest/pull/290) | `HttpEngine` interface + OkHttp backend; virtual threads; exact wire capture; adaptive concurrency; idle-time accounting | Requests get sent, fast, and we can see where the time went |
-| 1.4 | Interaction store (one SQLite file per run) and its query API | Every run is inspectable afterwards |
+| 1.4 ✅ [#291](https://github.com/isa-group/RESTest/pull/291) | Interaction store (one SQLite file per run) and its query API | Every run is inspectable afterwards |
 | 1.5 | Value provider chain and random providers; random test-case generator | The tool invents its own inputs |
 | 1.6 | Oracles: server error, response schema conformance. WFC fault codes, event stream, console and JSON reports | Real failures are reported, each with a `curl` command to reproduce it |
 | 1.7 | `restest run <spec> --url <base> --budget <duration>`; smoke integration test against two containerised APIs | The whole thing works from one command; regressions caught on every PR |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ its own pull request, so the table and the branch history never drift apart.
 | 1.1b ✅ [#285](https://github.com/isa-group/RESTest/pull/285) | Execution model: `TestCase`, value provenance, exact request and response payloads, `Interaction` and its outcome | A representation of what we did to the API, and what came back |
 | 1.2 ✅ [#287](https://github.com/isa-group/RESTest/pull/287), [#289](https://github.com/isa-group/RESTest/pull/289) | `SpecificationParser` interface + a single swagger-parser backend; OAS 2.0 (by conversion), 3.0.x and 3.1.x; lazy `$ref`; malformed operations, and any OAS 3.2 (or later) document, skipped and reported rather than failing the run | Point the tool at any real specification without it crashing |
 | 1.3 ✅ [#290](https://github.com/isa-group/RESTest/pull/290) | `HttpEngine` interface + OkHttp backend; virtual threads; exact wire capture; adaptive concurrency; idle-time accounting | Requests get sent, fast, and we can see where the time went |
-| 1.4 | Interaction store (SQLite + NDJSON) and its query API | Every run is inspectable afterwards |
+| 1.4 | Interaction store (one SQLite file per run) and its query API | Every run is inspectable afterwards |
 | 1.5 | Value provider chain and random providers; random test-case generator | The tool invents its own inputs |
 | 1.6 | Oracles: server error, response schema conformance. WFC fault codes, event stream, console and JSON reports | Real failures are reported, each with a `curl` command to reproduce it |
 | 1.7 | `restest run <spec> --url <base> --budget <duration>`; smoke integration test against two containerised APIs | The whole thing works from one command; regressions caught on every PR |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -114,7 +114,9 @@ observed is persisted, which is what makes offline re-analysis possible.
 2. **One event stream, many listeners.** Reports, metrics, feedback and oracles all subscribe.
    [ADR-0006](adr/0006-event-stream-and-store.md)
 3. **Persist everything.** The interaction store is what makes offline re-checking, corpus oracles
-   and honest post-hoc analysis possible, and it costs almost nothing.
+   and honest post-hoc analysis possible, and it costs almost nothing. One run is one SQLite file,
+   readable by anything that reads SQLite; NDJSON is one of the report formats at M3.5, not a second
+   store. [ADR-0006](adr/0006-event-stream-and-store.md), amended at M1.4
 4. **No global mutable state.** Two runs coexist in one JVM. Enforced by an architecture test.
 5. **The loop is never blocked; idle time is reported.** [ADR-0009](adr/0009-non-blocking-engine.md)
 6. **Narrow SPIs, service discovery, module boundaries.** A new oracle or provider is one class.
@@ -317,7 +319,8 @@ Versions are pinned here and in the root POM; the two are expected to agree.
 | Concurrency | Virtual threads | JDK 21+ |
 | IDL parser | ANTLR4 | 4.13.x |
 | Constraint solver | Choco, behind an interface | 4.10.x |
-| Interaction store | SQLite (`org.xerial:sqlite-jdbc`) plus NDJSON | — |
+| Interaction store | SQLite (`org.xerial:sqlite-jdbc`), one file per run ([ADR-0006](adr/0006-event-stream-and-store.md), amended at M1.4) | 3.50.3.0 |
+| JSON text, at the store's edge only | `com.fasterxml.jackson.core:jackson-core` | 2.22.1 |
 | Unit tests | JUnit Jupiter | 6.1.3 |
 | Assertions | AssertJ | 3.27.7 |
 | Container-based integration tests | Testcontainers | 2.0.5 |

--- a/docs/adr/0006-event-stream-and-store.md
+++ b/docs/adr/0006-event-stream-and-store.md
@@ -91,8 +91,13 @@ the golden corpus, and simpler for a reader to reason about."*
 - `restest-store` has exactly one `InteractionStore`, backed by SQLite: one file per run, the facts
   worth filtering on as indexed columns, and the interaction itself stored beside them as a JSON
   document.
-- That document is what M3.5's NDJSON report writes out, one row per line. There is one serialised
-  shape in the project, not two that can drift apart.
+- There is one serialised shape in the project, defined in one class (`InteractionDocument`), and
+  M3.5's NDJSON report writes *that* shape rather than inventing a second one. Note what this does
+  **not** yet settle: `restest-report` may not depend on `restest-store` under the current layer
+  rules, so M3.5 must either take that dependency deliberately (a rule change, argued at the time) or
+  move the document shape into `restest-core` — which can hold it without gaining a JSON library,
+  because building a `JsonValue` needs none; only turning it into text does. Whichever is chosen, the
+  requirement is that no second mapping from an interaction to JSON is written.
 - The `InteractionStore` interface stays, with one implementation behind it, for the reason it was
   introduced: it is what M3.3 and the corpus oracles consume, and replacing the container later is a
   change to one module.

--- a/docs/adr/0006-event-stream-and-store.md
+++ b/docs/adr/0006-event-stream-and-store.md
@@ -1,7 +1,7 @@
 # ADR-0006: One event stream, and every interaction persisted
 
-**Status:** Accepted
-**Date:** 2026-09-11
+**Status:** Accepted, amended at M1.4
+**Date:** 2026-09-11 (amended 2026-09-12)
 
 ## Context
 
@@ -33,7 +33,8 @@ Each oracle declares what it consumes, so the engine can schedule it correctly a
 can describe it.
 
 **Every interaction is persisted** — exact request and response bytes, timings, the test case that
-produced it, and the provenance of each parameter value. SQLite by default, NDJSON as an alternative.
+produced it, and the provenance of each parameter value. ~~SQLite by default, NDJSON as an
+alternative.~~ **Amended at M1.4: SQLite, and only SQLite.** See the amendment below.
 
 **`restest recheck <run>`** re-evaluates a stored run against a different oracle set, offline, with no
 API calls.
@@ -57,3 +58,51 @@ API calls.
   of how expensive "later" was for 1.x's stateful support.
 - **Keeping results only in memory.** Cheaper, and forecloses `recheck`, corpus oracles and any
   post-hoc analysis.
+
+## Amendment (M1.4)
+
+**Date:** 2026-09-12
+
+**One store, not two: SQLite. NDJSON is a report format, not a second container.**
+
+### Why
+
+The original decision named NDJSON "an alternative", and building it at M1.4 would have meant two
+implementations of one interface, doing the same job, maintained in parallel for the life of the
+project. They do not complement each other: whichever one a run uses, the other is idle.
+
+The roadmap already places NDJSON where it earns its keep — **M3.5**, among the report formats,
+beside HTML, JUnit XML and HAR. That is what design principle 8 (open formats out) actually asks for:
+that a finished run can leave RESTest in a format anybody can read, not that RESTest keep two kinds
+of database.
+
+They are also not equally good at the job the store exists to do. Everything downstream of the store
+asks it questions repeatedly — `restest recheck` (M3.3), corpus oracles, reports. SQLite answers them
+from an index; a plain-text file answers them by parsing itself from the beginning, every time, and
+holds no more than a run's worth in memory while doing it. A run killed halfway leaves a database
+consistent and a text file with half a line in it.
+
+This is the same trade ADR-0007 made at M1.2 when it went back to one parser backend, for the same
+reason stated there: *"One well-tested backend is simpler to build, simpler to keep passing against
+the golden corpus, and simpler for a reader to reason about."*
+
+### How
+
+- `restest-store` has exactly one `InteractionStore`, backed by SQLite: one file per run, the facts
+  worth filtering on as indexed columns, and the interaction itself stored beside them as a JSON
+  document.
+- That document is what M3.5's NDJSON report writes out, one row per line. There is one serialised
+  shape in the project, not two that can drift apart.
+- The `InteractionStore` interface stays, with one implementation behind it, for the reason it was
+  introduced: it is what M3.3 and the corpus oracles consume, and replacing the container later is a
+  change to one module.
+
+### Consequences
+
+- Half the code and half the tests for the same capability, and one on-disk shape to keep correct.
+- A stored run is readable without RESTest by anything that reads SQLite — `sqlite3`, a notebook, a
+  spreadsheet — and the document column is readable by anything that reads JSON. "Open formats out"
+  is satisfied at M1.4, and satisfied again as a file anyone can `grep` at M3.5.
+- The tool now depends on a database driver that carries native libraries. The GraalVM native binary
+  at M7.3 will need configuration for it. This is routine, and it is the price of not having a
+  pure-Java container; it is recorded here so M7.3 does not meet it as a surprise.

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,16 @@
         <snakeyaml.version>2.6</snakeyaml.version>
         <okhttp.version>5.5.0</okhttp.version>
         <wiremock.version>3.13.2</wiremock.version>
+        <sqlite.version>3.50.3.0</sqlite.version>
+        <jackson.version>2.22.1</jackson.version>
+
+        <!--
+          Default for the JVM arguments surefire passes on. JaCoCo's prepare-agent goal replaces
+          this with the agent it needs, so a module adding its own argument writes
+          "@{argLine} ..." and keeps coverage working; this empty default is what stops that
+          reference from failing to resolve when coverage is switched off.
+        -->
+        <argLine></argLine>
     </properties>
 
     <dependencyManagement>
@@ -120,6 +130,16 @@
                 <groupId>org.wiremock</groupId>
                 <artifactId>wiremock</artifactId>
                 <version>${wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.xerial</groupId>
+                <artifactId>sqlite-jdbc</artifactId>
+                <version>${sqlite.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRules.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRules.java
@@ -106,9 +106,10 @@ final class ArchitectureRules {
 
     /**
      * A third-party library is confined to one module, so replacing it later is a change limited to
-     * that one module. Two of them are: the library that reads OpenAPI documents, and the one that
-     * sends HTTP requests. The forbidden package is a parameter so the self-test can point the same
-     * rule at something it can actually depend on, without needing either real library itself.
+     * that one module. Four are, so far: the library that reads OpenAPI documents, the one that sends
+     * HTTP requests, the database that stores a run, and the one that turns JSON into text. The
+     * forbidden package is a parameter so the self-test can point the same rule at something it can
+     * actually depend on, without needing any of those real libraries itself.
      */
     static ArchRule onlyOneModuleDependsOn(String root, String module, String forbiddenPackage) {
         return noClasses()

--- a/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRules.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/ArchitectureRules.java
@@ -117,7 +117,7 @@ final class ArchitectureRules {
                 .and().resideInAPackage(root + "..")
                 .should().dependOnClassesThat().resideInAPackage(forbiddenPackage)
                 .as("only " + root + "." + module + " depends on " + forbiddenPackage
-                        + " (ADR-0007)");
+                        + " (ADR-0004)");
     }
 
     /**

--- a/restest-arch-tests/src/test/java/io/restest/arch/ProductionArchitectureTest.java
+++ b/restest-arch-tests/src/test/java/io/restest/arch/ProductionArchitectureTest.java
@@ -68,6 +68,13 @@ class ProductionArchitectureTest {
     }
 
     @Test
+    @DisplayName("only restest-store references the database driver and the JSON library (ADR-0004)")
+    void only_restest_store_references_the_database_and_json_libraries() {
+        check(ArchitectureRules.onlyOneModuleDependsOn(ROOT, "store", "org.sqlite.."));
+        check(ArchitectureRules.onlyOneModuleDependsOn(ROOT, "store", "com.fasterxml.."));
+    }
+
+    @Test
     @DisplayName("only restest-cli terminates the process (ADR-0004)")
     void only_restest_cli_terminates_the_process() {
         check(ArchitectureRules.onlyOneModuleMayTerminateTheProcess(ROOT, "cli"));

--- a/restest-core/src/main/java/io/restest/core/store/InteractionQuery.java
+++ b/restest-core/src/main/java/io/restest/core/store/InteractionQuery.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.core.store;
+
+import io.restest.core.model.OperationId;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A question to ask a store of past interactions: which of them do you want back?
+ *
+ * <p>Every part is optional, and the ones given are combined: a query naming an operation and the
+ * status code 500 asks for the times that one operation answered with a server error. A query naming
+ * nothing asks for everything.
+ *
+ * <p>The factory methods are named after the questions people actually ask - "what did this
+ * operation do", "what came back as a server error", "what never answered at all" - and each returns
+ * a new query rather than changing this one, so a query can be kept and reused without anyone else's
+ * additions leaking into it.
+ *
+ * @param operation only interactions belonging to this operation
+ * @param statusCode only replies with exactly this status code
+ * @param statusClass only replies whose status code starts with this digit: 5 for the server errors,
+ *     4 for the requests the API refused, 2 for the ones it accepted
+ * @param outcome only interactions that ended this way
+ * @param limit at most this many, for a caller that wants a sample rather than a corpus. The store
+ *     returns them oldest first, so a limit takes the beginning of the run rather than an arbitrary
+ *     handful
+ */
+public record InteractionQuery(
+        Optional<OperationId> operation,
+        Optional<Integer> statusCode,
+        Optional<Integer> statusClass,
+        Optional<Outcome> outcome,
+        Optional<Integer> limit) {
+
+    /** The three ways an attempt can end, as something a query can name. */
+    public enum Outcome {
+
+        /** The API answered, whatever it answered. */
+        ANSWERED,
+
+        /** Something came back, but not a whole reply. */
+        MALFORMED,
+
+        /** Nothing came back at all: refused, timed out, unreachable. */
+        FAILED
+    }
+
+    private static final InteractionQuery ALL = new InteractionQuery(Optional.empty(),
+            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+
+    public InteractionQuery {
+        Objects.requireNonNull(operation, "operation");
+        Objects.requireNonNull(statusCode, "statusCode");
+        Objects.requireNonNull(statusClass, "statusClass");
+        Objects.requireNonNull(outcome, "outcome");
+        Objects.requireNonNull(limit, "limit");
+        statusCode.ifPresent(code -> {
+            if (code < 100 || code > 599) {
+                throw new IllegalArgumentException(
+                        "an HTTP status code is between 100 and 599: " + code);
+            }
+        });
+        statusClass.ifPresent(digit -> {
+            if (digit < 1 || digit > 5) {
+                throw new IllegalArgumentException("a class of status codes is named by its first "
+                        + "digit, 1 to 5, not by " + digit);
+            }
+        });
+        limit.ifPresent(count -> {
+            if (count < 1) {
+                throw new IllegalArgumentException(
+                        "asking for at most " + count + " interactions is asking for none");
+            }
+        });
+    }
+
+    /** Everything the store holds. */
+    public static InteractionQuery all() {
+        return ALL;
+    }
+
+    /** Everything one operation did. */
+    public static InteractionQuery forOperation(OperationId operation) {
+        return ALL.andOperation(operation);
+    }
+
+    /** Every reply with exactly this status code. */
+    public static InteractionQuery withStatus(int statusCode) {
+        return ALL.andStatus(statusCode);
+    }
+
+    /** Every reply the API answered with a server error, which is the first thing anyone asks. */
+    public static InteractionQuery serverErrors() {
+        return ALL.andStatusClass(5);
+    }
+
+    /** Every attempt the API never answered: refused, timed out, or cut short. */
+    public static InteractionQuery neverAnswered() {
+        return ALL.andOutcome(Outcome.FAILED);
+    }
+
+    public InteractionQuery andOperation(OperationId value) {
+        return new InteractionQuery(Optional.of(Objects.requireNonNull(value, "value")), statusCode,
+                statusClass, outcome, limit);
+    }
+
+    public InteractionQuery andStatus(int value) {
+        return new InteractionQuery(operation, Optional.of(value), statusClass, outcome, limit);
+    }
+
+    public InteractionQuery andStatusClass(int firstDigit) {
+        return new InteractionQuery(operation, statusCode, Optional.of(firstDigit), outcome, limit);
+    }
+
+    public InteractionQuery andOutcome(Outcome value) {
+        return new InteractionQuery(operation, statusCode, statusClass,
+                Optional.of(Objects.requireNonNull(value, "value")), limit);
+    }
+
+    /** The same question, answered with at most this many interactions. */
+    public InteractionQuery limitedTo(int count) {
+        return new InteractionQuery(operation, statusCode, statusClass, outcome,
+                Optional.of(count));
+    }
+
+    /** Whether this query asks for everything, which a store may be able to answer more cheaply. */
+    public boolean isUnfiltered() {
+        return operation.isEmpty() && statusCode.isEmpty() && statusClass.isEmpty()
+                && outcome.isEmpty();
+    }
+}

--- a/restest-core/src/main/java/io/restest/core/store/InteractionStore.java
+++ b/restest-core/src/main/java/io/restest/core/store/InteractionStore.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.core.store;
+
+import io.restest.core.execution.Interaction;
+import io.restest.core.execution.InteractionId;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Where everything a run did to an API is kept, so that it can be looked at afterwards.
+ *
+ * <p>A test run is an experiment, and an experiment nobody can re-examine is worth very little. So
+ * every attempt is written down in full - the request as it was sent, the reply as it came back, how
+ * long it took, which test it belonged to, and where each value in it came from - and it stays there
+ * when the run ends. That is what lets a person ask "show me everything that returned a server error"
+ * hours later, what lets a new way of judging replies be tried against a run that already happened
+ * without touching the API again, and what makes a report something that can be regenerated rather
+ * than something that had to be captured while the run was alive.
+ *
+ * <p>A store is opened for a run and used until it ends. It is safe to use from several threads at
+ * once, because requests are sent from many at once. Two stores can be open in the same program
+ * without either seeing the other's interactions.
+ *
+ * <p>Everything here can throw {@link InteractionStoreException}, and nothing else does.
+ */
+public interface InteractionStore extends AutoCloseable {
+
+    /**
+     * Writes one interaction down.
+     *
+     * <p>Recording the same interaction twice is not an error: the second one replaces the first,
+     * which is what makes a re-run of the same attempt after a crash produce one row rather than two.
+     *
+     * @param interaction what was tried, sent, and came back. Never {@code null}
+     */
+    void record(Interaction interaction);
+
+    /**
+     * Every interaction matching the question, oldest first.
+     *
+     * @param query what to look for; {@link InteractionQuery#all()} for everything
+     * @return the matching interactions, exactly as they were recorded
+     */
+    List<Interaction> find(InteractionQuery query);
+
+    /**
+     * How many interactions match the question.
+     *
+     * <p>Separate from {@link #find} because counting a hundred thousand interactions should not
+     * mean building a hundred thousand of them in memory first.
+     *
+     * @param query what to count; {@link InteractionQuery#all()} for everything
+     * @return how many there are
+     */
+    long count(InteractionQuery query);
+
+    /**
+     * One interaction by its identifier.
+     *
+     * @param id the identifier the interaction was recorded under
+     * @return the interaction, or empty if this store has never seen it
+     */
+    Optional<Interaction> byId(InteractionId id);
+
+    /**
+     * Finishes writing and releases the file.
+     *
+     * <p>Closing twice is harmless. Everything recorded before closing is on disk afterwards, which
+     * is the promise the whole interface rests on.
+     */
+    @Override
+    void close();
+}

--- a/restest-core/src/main/java/io/restest/core/store/InteractionStore.java
+++ b/restest-core/src/main/java/io/restest/core/store/InteractionStore.java
@@ -45,6 +45,10 @@ public interface InteractionStore extends AutoCloseable {
      * <p>Recording the same interaction twice is not an error: the second one replaces the first,
      * which is what makes a re-run of the same attempt after a crash produce one row rather than two.
      *
+     * <p>The writing happens on the calling thread and is finished when this returns, so a caller
+     * that must not wait for a disk - the loop that decides what to send next, above all - should
+     * hand the interaction to something else to record rather than call this from there.
+     *
      * @param interaction what was tried, sent, and came back. Never {@code null}
      */
     void record(Interaction interaction);

--- a/restest-core/src/main/java/io/restest/core/store/InteractionStoreException.java
+++ b/restest-core/src/main/java/io/restest/core/store/InteractionStoreException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.core.store;
+
+/**
+ * Thrown when the evidence of a run cannot be written down or read back: the disk is full, the file
+ * is not where it was, the database is corrupt.
+ *
+ * <p>Almost nothing else in RESTest throws. A specification that cannot be read and an API that
+ * refuses to answer are the tool's subject matter, and both are reported rather than raised. This is
+ * the exception to that, and deliberately so: a run whose evidence is being silently dropped is
+ * producing nothing of value, and carrying on quietly would waste the whole budget before anyone
+ * noticed.
+ */
+public class InteractionStoreException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InteractionStoreException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InteractionStoreException(String message) {
+        super(message);
+    }
+}

--- a/restest-core/src/main/java/module-info.java
+++ b/restest-core/src/main/java/module-info.java
@@ -20,11 +20,11 @@
  * shapes ({@code schema}) that data must follow. Every other part of RESTest is built on top of
  * these definitions.
  *
- * <p>Six packages are exported and one is not. {@code io.restest.core.internal} holds small
- * helpers shared between the other six and is deliberately kept internal, so it can change freely
+ * <p>Seven packages are exported and one is not. {@code io.restest.core.internal} holds small
+ * helpers shared between the other seven and is deliberately kept internal, so it can change freely
  * without affecting anything built on top of this module.
  *
- * <p>Two of the six have names close enough to be worth telling apart on sight.
+ * <p>Two of the seven have names close enough to be worth telling apart on sight.
  * {@code io.restest.core.execution} is data: one test attempt, the request sent, the reply received.
  * {@code io.restest.core.exec} is the door that produces that data - the interface an HTTP client
  * implements - and it is named after the module that implements it, {@code restest-exec}, exactly as
@@ -42,4 +42,5 @@ module io.restest.core {
     exports io.restest.core.model;
     exports io.restest.core.schema;
     exports io.restest.core.spec;
+    exports io.restest.core.store;
 }

--- a/restest-core/src/test/java/io/restest/core/store/InteractionQueryTest.java
+++ b/restest-core/src/test/java/io/restest/core/store/InteractionQueryTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.core.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import io.restest.core.model.OperationId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class InteractionQueryTest {
+
+    @Test
+    @DisplayName("a query with nothing in it asks for everything")
+    void the_empty_query_asks_for_everything() {
+        InteractionQuery all = InteractionQuery.all();
+
+        assertThat(all.isUnfiltered()).isTrue();
+        assertThat(all.operation()).isEmpty();
+        assertThat(all.limit()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("the named questions are the ones people actually ask")
+    void the_factories_build_the_questions_they_name() {
+        assertThat(InteractionQuery.serverErrors().statusClass()).contains(5);
+        assertThat(InteractionQuery.withStatus(404).statusCode()).contains(404);
+        assertThat(InteractionQuery.neverAnswered().outcome())
+                .contains(InteractionQuery.Outcome.FAILED);
+        assertThat(InteractionQuery.forOperation(OperationId.of("GET /pets")).operation())
+                .contains(OperationId.of("GET /pets"));
+    }
+
+    @Test
+    @DisplayName("parts of a question combine, and adding one leaves the original alone")
+    void queries_combine_without_changing_each_other() {
+        InteractionQuery errors = InteractionQuery.serverErrors();
+        InteractionQuery errorsFromOne = errors.andOperation(OperationId.of("GET /pets"))
+                .limitedTo(10);
+
+        assertThat(errorsFromOne.statusClass()).contains(5);
+        assertThat(errorsFromOne.operation()).contains(OperationId.of("GET /pets"));
+        assertThat(errorsFromOne.limit()).contains(10);
+        assertThat(errorsFromOne.isUnfiltered()).isFalse();
+        assertThat(errors.operation())
+                .describedAs("a query is a value: keeping one and adding to it must not change it")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("a question nothing could answer is refused where it is written, not later")
+    void impossible_questions_are_refused() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> InteractionQuery.withStatus(99))
+                .withMessageContaining("between 100 and 599");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> InteractionQuery.all().andStatusClass(7))
+                .withMessageContaining("first digit");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> InteractionQuery.all().limitedTo(0))
+                .withMessageContaining("asking for none");
+    }
+}

--- a/restest-store/pom.xml
+++ b/restest-store/pom.xml
@@ -21,5 +21,38 @@
             <artifactId>restest-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+        </dependency>
+
+        <!--
+          Only the streaming reader and writer, not the object mapper: this module turns RESTest's
+          own JSON values into text and back, and has no use for a library that maps Java objects to
+          JSON. Keeping to jackson-core also keeps the dependency small and its surface tiny.
+        -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--
+                      The SQLite driver is a Java wrapper around a small native library, which it
+                      loads at startup. Recent JVMs warn about that unless the program says it is
+                      expected, and a future one will refuse it outright. Saying so here keeps the
+                      test output free of a warning that means nothing is wrong, and records where
+                      the native code enters the build.
+                    -->
+                    <argLine>@{argLine} --enable-native-access=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/restest-store/src/main/java/io/restest/store/InteractionDocument.java
+++ b/restest-store/src/main/java/io/restest/store/InteractionDocument.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.store;
+
+import io.restest.core.execution.BodyValue;
+import io.restest.core.execution.Header;
+import io.restest.core.execution.HttpRequestRecord;
+import io.restest.core.execution.HttpResponseRecord;
+import io.restest.core.execution.Interaction;
+import io.restest.core.execution.InteractionId;
+import io.restest.core.execution.InteractionOutcome;
+import io.restest.core.execution.ParameterValue;
+import io.restest.core.execution.Payload;
+import io.restest.core.execution.StatusLine;
+import io.restest.core.execution.TestCase;
+import io.restest.core.execution.TestCaseId;
+import io.restest.core.execution.ValueOrigin;
+import io.restest.core.json.JsonValue;
+import io.restest.core.model.HttpMethod;
+import io.restest.core.model.OperationId;
+import io.restest.core.model.ParameterLocation;
+import io.restest.core.store.InteractionStoreException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The shape one interaction takes on disk, and how it gets back out again.
+ *
+ * <p>Everything a run did is stored as a JSON object of this shape - the request as it was sent, the
+ * reply as it came back, which test it belonged to and where every value in it came from. Keeping it
+ * as JSON rather than spreading it across database columns has two payoffs: the stored run can be
+ * read by anything that reads JSON, without RESTest and without knowing its database layout, and a
+ * new field in the model does not mean a new column and a migration for every run ever stored.
+ *
+ * <p>Bodies get the treatment that makes a stored run readable by a person. A body whose bytes are
+ * valid text is stored as that text, so a JSON reply in a stored run looks like a JSON reply. A body
+ * that is not - an image, a compressed file, a malformed reply - is stored as base64 instead, so
+ * nothing is lost or quietly mangled. The two cases are told apart by which name the body is stored
+ * under, so nobody has to guess.
+ *
+ * <p>Times are written the way the rest of the world writes them: an instant as
+ * {@code 2026-09-12T16:00:00Z} and a duration as {@code PT0.403S}. Both read plainly and both come
+ * back exactly as they went in.
+ */
+final class InteractionDocument {
+
+    private InteractionDocument() {
+    }
+
+    static JsonValue of(Interaction interaction) {
+        Map<String, JsonValue> document = new LinkedHashMap<>();
+        document.put("id", JsonValue.of(interaction.id().value()));
+        document.put("sentAt", JsonValue.of(interaction.sentAt().toString()));
+        document.put("elapsed", JsonValue.of(interaction.elapsed().toString()));
+        document.put("testCase", of(interaction.testCase()));
+        document.put("request", of(interaction.request()));
+        document.put("outcome", of(interaction.outcome()));
+        return JsonValue.object(document);
+    }
+
+    static Interaction toInteraction(JsonValue value) {
+        JsonValue.JsonObject document = object(value, "the interaction");
+        return new Interaction(
+                InteractionId.of(string(document, "id")),
+                toTestCase(member(document, "testCase")),
+                toRequest(member(document, "request")),
+                toOutcome(member(document, "outcome")),
+                Instant.parse(string(document, "sentAt")),
+                Duration.parse(string(document, "elapsed")));
+    }
+
+    // --- the test case -------------------------------------------------------------------------
+
+    private static JsonValue of(TestCase testCase) {
+        Map<String, JsonValue> document = new LinkedHashMap<>();
+        document.put("id", JsonValue.of(testCase.id().value()));
+        document.put("operation", JsonValue.of(testCase.operation().value()));
+        document.put("parameters", JsonValue.array(
+                testCase.parameterValues().stream().map(InteractionDocument::of).toList()));
+        testCase.body().ifPresent(body -> document.put("body", of(body)));
+        return JsonValue.object(document);
+    }
+
+    private static TestCase toTestCase(JsonValue value) {
+        JsonValue.JsonObject document = object(value, "the test case");
+        List<ParameterValue> parameters = array(document, "parameters").stream()
+                .map(InteractionDocument::toParameterValue)
+                .toList();
+        return new TestCase(
+                TestCaseId.of(string(document, "id")),
+                OperationId.of(string(document, "operation")),
+                parameters,
+                document.member("body").map(InteractionDocument::toBodyValue));
+    }
+
+    private static JsonValue of(ParameterValue parameter) {
+        Map<String, JsonValue> document = new LinkedHashMap<>();
+        document.put("name", JsonValue.of(parameter.name()));
+        document.put("in", JsonValue.of(parameter.location().name()));
+        document.put("value", parameter.value());
+        document.put("origin", of(parameter.origin()));
+        return JsonValue.object(document);
+    }
+
+    private static ParameterValue toParameterValue(JsonValue value) {
+        JsonValue.JsonObject document = object(value, "a parameter value");
+        return new ParameterValue(
+                string(document, "name"),
+                ParameterLocation.valueOf(string(document, "in")),
+                member(document, "value"),
+                toOrigin(member(document, "origin")));
+    }
+
+    private static JsonValue of(BodyValue body) {
+        return JsonValue.object(new LinkedHashMap<>(Map.of(
+                "mediaType", JsonValue.of(body.mediaType()),
+                "value", body.value(),
+                "origin", of(body.origin()))));
+    }
+
+    private static BodyValue toBodyValue(JsonValue value) {
+        JsonValue.JsonObject document = object(value, "the body that was sent");
+        return new BodyValue(string(document, "mediaType"), member(document, "value"),
+                toOrigin(member(document, "origin")));
+    }
+
+    /**
+     * Where a value came from: the document said so, something invented it, or it was taken out of an
+     * earlier reply. The last of those is what makes a run explainable afterwards - it says which
+     * request handed this one the identifier it used.
+     */
+    private static JsonValue of(ValueOrigin origin) {
+        Map<String, JsonValue> document = new LinkedHashMap<>();
+        switch (origin) {
+            case ValueOrigin.Declared ignored -> document.put("kind", JsonValue.of("declared"));
+            case ValueOrigin.Generated generated -> {
+                document.put("kind", JsonValue.of("generated"));
+                document.put("source", JsonValue.of(generated.source()));
+            }
+            case ValueOrigin.Derived derived -> {
+                document.put("kind", JsonValue.of("derived"));
+                document.put("from", JsonValue.of(derived.from().value()));
+                document.put("description", JsonValue.of(derived.description()));
+            }
+        }
+        return JsonValue.object(document);
+    }
+
+    private static ValueOrigin toOrigin(JsonValue value) {
+        JsonValue.JsonObject document = object(value, "where a value came from");
+        String kind = string(document, "kind");
+        return switch (kind) {
+            case "declared" -> ValueOrigin.DECLARED;
+            case "generated" -> new ValueOrigin.Generated(string(document, "source"));
+            case "derived" -> new ValueOrigin.Derived(
+                    InteractionId.of(string(document, "from")), string(document, "description"));
+            default -> throw new InteractionStoreException(
+                    "A value came from '" + kind + "', which is not something this version knows");
+        };
+    }
+
+    // --- the request and the reply -------------------------------------------------------------
+
+    private static JsonValue of(HttpRequestRecord request) {
+        Map<String, JsonValue> document = new LinkedHashMap<>();
+        document.put("method", JsonValue.of(request.method().name()));
+        document.put("url", JsonValue.of(request.url()));
+        document.put("headers", of(request.headers()));
+        request.body().ifPresent(body -> document.put("body", of(body)));
+        return JsonValue.object(document);
+    }
+
+    private static HttpRequestRecord toRequest(JsonValue value) {
+        JsonValue.JsonObject document = object(value, "the request");
+        HttpMethod method = HttpMethod.named(string(document, "method"))
+                .orElseThrow(() -> new InteractionStoreException("A request was recorded with the "
+                        + "method '" + string(document, "method") + "', which is not one this "
+                        + "version knows"));
+        return new HttpRequestRecord(method, string(document, "url"),
+                toHeaders(document), document.member("body").map(InteractionDocument::toPayload));
+    }
+
+    private static JsonValue of(InteractionOutcome outcome) {
+        Map<String, JsonValue> document = new LinkedHashMap<>();
+        switch (outcome) {
+            case InteractionOutcome.Answered answered -> {
+                document.put("kind", JsonValue.of("answered"));
+                HttpResponseRecord response = answered.response();
+                document.putAll(of(response.statusLine()));
+                document.put("headers", of(response.headers()));
+                response.body().ifPresent(body -> document.put("body", of(body)));
+            }
+            case InteractionOutcome.MalformedResponse malformed -> {
+                document.put("kind", JsonValue.of("malformed"));
+                document.put("reason", JsonValue.of(malformed.reason()));
+                malformed.statusLine().ifPresent(line -> document.putAll(of(line)));
+                document.put("headers", of(malformed.headers()));
+                malformed.partial().ifPresent(body -> document.put("body", of(body)));
+            }
+            case InteractionOutcome.TransportFailure failure -> {
+                document.put("kind", JsonValue.of("failed"));
+                document.put("reason", JsonValue.of(failure.reason()));
+            }
+        }
+        return JsonValue.object(document);
+    }
+
+    private static InteractionOutcome toOutcome(JsonValue value) {
+        JsonValue.JsonObject document = object(value, "how the attempt ended");
+        String kind = string(document, "kind");
+        Optional<Payload> body = document.member("body").map(InteractionDocument::toPayload);
+        return switch (kind) {
+            case "answered" -> new InteractionOutcome.Answered(new HttpResponseRecord(
+                    toStatusLine(document).orElseThrow(() -> new InteractionStoreException(
+                            "An answered interaction was recorded without a status code")),
+                    toHeaders(document), body));
+            case "malformed" -> new InteractionOutcome.MalformedResponse(
+                    string(document, "reason"), toStatusLine(document), toHeaders(document), body);
+            case "failed" -> new InteractionOutcome.TransportFailure(string(document, "reason"));
+            default -> throw new InteractionStoreException(
+                    "An attempt ended as '" + kind + "', which is not something this version knows");
+        };
+    }
+
+    private static Map<String, JsonValue> of(StatusLine statusLine) {
+        Map<String, JsonValue> document = new LinkedHashMap<>();
+        document.put("status", JsonValue.of(statusLine.statusCode()));
+        statusLine.reasonPhrase().ifPresent(phrase ->
+                document.put("statusText", JsonValue.of(phrase)));
+        statusLine.protocolVersion().ifPresent(protocol ->
+                document.put("protocol", JsonValue.of(protocol)));
+        return document;
+    }
+
+    private static Optional<StatusLine> toStatusLine(JsonValue.JsonObject document) {
+        return document.member("status").map(status -> new StatusLine(
+                number(status, "status").intValueExact(),
+                document.member("statusText").map(text -> text(text, "statusText")),
+                document.member("protocol").map(protocol -> text(protocol, "protocol"))));
+    }
+
+    private static JsonValue of(List<Header> headers) {
+        return JsonValue.array(headers.stream()
+                .map(header -> (JsonValue) JsonValue.object(new LinkedHashMap<>(Map.of(
+                        "name", JsonValue.of(header.name()),
+                        "value", JsonValue.of(header.value())))))
+                .toList());
+    }
+
+    private static List<Header> toHeaders(JsonValue.JsonObject document) {
+        List<Header> headers = new ArrayList<>();
+        for (JsonValue header : array(document, "headers")) {
+            JsonValue.JsonObject one = object(header, "a header");
+            headers.add(Header.of(string(one, "name"), string(one, "value")));
+        }
+        return headers;
+    }
+
+    // --- bodies --------------------------------------------------------------------------------
+
+    private static JsonValue of(Payload payload) {
+        Map<String, JsonValue> document = new LinkedHashMap<>();
+        document.put("mediaType", JsonValue.of(payload.mediaType()));
+        byte[] content = payload.content();
+        asText(content).ifPresentOrElse(
+                text -> document.put("text", JsonValue.of(text)),
+                () -> document.put("base64",
+                        JsonValue.of(Base64.getEncoder().encodeToString(content))));
+        if (payload.truncated()) {
+            document.put("wireLength", JsonValue.of(payload.deliveredLength()));
+        }
+        return JsonValue.object(document);
+    }
+
+    private static Payload toPayload(JsonValue value) {
+        JsonValue.JsonObject document = object(value, "a body");
+        String mediaType = string(document, "mediaType");
+        byte[] content = document.member("text")
+                .map(text -> text(text, "text").getBytes(StandardCharsets.UTF_8))
+                .orElseGet(() -> Base64.getDecoder().decode(string(document, "base64")));
+        return document.member("wireLength")
+                .map(length -> Payload.partial(content, mediaType,
+                        number(length, "wireLength").longValueExact()))
+                .orElseGet(() -> Payload.of(content, mediaType));
+    }
+
+    /**
+     * The bytes as text, if they really are text.
+     *
+     * <p>Strictly decoded on purpose: a decoder that quietly replaces the bytes it does not
+     * understand would turn "this reply was not valid text" - which is a finding - into a body full
+     * of question marks that came back different from how it went in.
+     */
+    private static Optional<String> asText(byte[] content) {
+        try {
+            CharBuffer decoded = StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(content));
+            return Optional.of(decoded.toString());
+        } catch (CharacterCodingException notText) {
+            return Optional.empty();
+        }
+    }
+
+    // --- reading the document ------------------------------------------------------------------
+
+    private static JsonValue.JsonObject object(JsonValue value, String what) {
+        if (value instanceof JsonValue.JsonObject object) {
+            return object;
+        }
+        throw new InteractionStoreException(
+                "A stored interaction is not shaped as it should be: " + what + " is not an object");
+    }
+
+    private static JsonValue member(JsonValue.JsonObject document, String name) {
+        return document.member(name).orElseThrow(() -> new InteractionStoreException(
+                "A stored interaction is missing its '" + name + "'"));
+    }
+
+    private static String string(JsonValue.JsonObject document, String name) {
+        return text(member(document, name), name);
+    }
+
+    private static String text(JsonValue value, String name) {
+        if (value instanceof JsonValue.JsonString string) {
+            return string.value();
+        }
+        throw new InteractionStoreException("A stored interaction's '" + name + "' is not text");
+    }
+
+    private static java.math.BigDecimal number(JsonValue value, String name) {
+        if (value instanceof JsonValue.JsonNumber number) {
+            return number.value();
+        }
+        throw new InteractionStoreException("A stored interaction's '" + name + "' is not a number");
+    }
+
+    private static List<JsonValue> array(JsonValue.JsonObject document, String name) {
+        JsonValue value = member(document, name);
+        if (value instanceof JsonValue.JsonArray array) {
+            return array.elements();
+        }
+        throw new InteractionStoreException("A stored interaction's '" + name + "' is not a list");
+    }
+}

--- a/restest-store/src/main/java/io/restest/store/InteractionDocument.java
+++ b/restest-store/src/main/java/io/restest/store/InteractionDocument.java
@@ -66,12 +66,18 @@ import java.util.Optional;
  * {@code 2026-09-12T16:00:00Z} and a duration as {@code PT0.403S}. Both read plainly and both come
  * back exactly as they went in.
  */
-final class InteractionDocument {
+public final class InteractionDocument {
 
     private InteractionDocument() {
     }
 
-    static JsonValue of(Interaction interaction) {
+    /**
+     * The interaction as the JSON object it is stored as.
+     *
+     * @param interaction what was tried, sent and came back
+     * @return the document
+     */
+    public static JsonValue of(Interaction interaction) {
         Map<String, JsonValue> document = new LinkedHashMap<>();
         document.put("id", JsonValue.of(interaction.id().value()));
         document.put("sentAt", JsonValue.of(interaction.sentAt().toString()));
@@ -82,15 +88,32 @@ final class InteractionDocument {
         return JsonValue.object(document);
     }
 
-    static Interaction toInteraction(JsonValue value) {
+    /**
+     * The interaction a stored document describes.
+     *
+     * <p>A document that is not one - written by a later version of RESTest, or edited by hand into
+     * something impossible - is reported as a stored interaction that could not be read, rather than
+     * as whatever low-level complaint the mangled part happened to produce.
+     *
+     * @param value the stored document
+     * @return the interaction it describes
+     */
+    public static Interaction toInteraction(JsonValue value) {
         JsonValue.JsonObject document = object(value, "the interaction");
-        return new Interaction(
-                InteractionId.of(string(document, "id")),
-                toTestCase(member(document, "testCase")),
-                toRequest(member(document, "request")),
-                toOutcome(member(document, "outcome")),
-                Instant.parse(string(document, "sentAt")),
-                Duration.parse(string(document, "elapsed")));
+        try {
+            return new Interaction(
+                    InteractionId.of(string(document, "id")),
+                    toTestCase(member(document, "testCase")),
+                    toRequest(member(document, "request")),
+                    toOutcome(member(document, "outcome")),
+                    Instant.parse(string(document, "sentAt")),
+                    Duration.parse(string(document, "elapsed")));
+        } catch (InteractionStoreException alreadyExplained) {
+            throw alreadyExplained;
+        } catch (RuntimeException e) {
+            throw new InteractionStoreException("A stored interaction could not be read back: "
+                    + e.getClass().getSimpleName() + ": " + e.getMessage(), e);
+        }
     }
 
     // --- the test case -------------------------------------------------------------------------
@@ -136,10 +159,11 @@ final class InteractionDocument {
     }
 
     private static JsonValue of(BodyValue body) {
-        return JsonValue.object(new LinkedHashMap<>(Map.of(
-                "mediaType", JsonValue.of(body.mediaType()),
-                "value", body.value(),
-                "origin", of(body.origin()))));
+        Map<String, JsonValue> document = new LinkedHashMap<>();
+        document.put("mediaType", JsonValue.of(body.mediaType()));
+        document.put("value", body.value());
+        document.put("origin", of(body.origin()));
+        return JsonValue.object(document);
     }
 
     private static BodyValue toBodyValue(JsonValue value) {
@@ -265,10 +289,18 @@ final class InteractionDocument {
 
     private static JsonValue of(List<Header> headers) {
         return JsonValue.array(headers.stream()
-                .map(header -> (JsonValue) JsonValue.object(new LinkedHashMap<>(Map.of(
-                        "name", JsonValue.of(header.name()),
-                        "value", JsonValue.of(header.value())))))
+                .map(InteractionDocument::of)
                 .toList());
+    }
+
+    private static JsonValue of(Header header) {
+        // Written member by member, not built from a map literal: the order of a small map literal
+        // is scrambled differently in every run of the program, and a stored run that came out
+        // byte-different every time would be impossible to compare with itself.
+        Map<String, JsonValue> document = new LinkedHashMap<>();
+        document.put("name", JsonValue.of(header.name()));
+        document.put("value", JsonValue.of(header.value()));
+        return JsonValue.object(document);
     }
 
     private static List<Header> toHeaders(JsonValue.JsonObject document) {
@@ -290,9 +322,8 @@ final class InteractionDocument {
                 text -> document.put("text", JsonValue.of(text)),
                 () -> document.put("base64",
                         JsonValue.of(Base64.getEncoder().encodeToString(content))));
-        if (payload.truncated()) {
-            document.put("wireLength", JsonValue.of(payload.deliveredLength()));
-        }
+        payload.wireLength().ifPresent(length ->
+                document.put("wireLength", JsonValue.of(length)));
         return JsonValue.object(document);
     }
 
@@ -302,10 +333,8 @@ final class InteractionDocument {
         byte[] content = document.member("text")
                 .map(text -> text(text, "text").getBytes(StandardCharsets.UTF_8))
                 .orElseGet(() -> Base64.getDecoder().decode(string(document, "base64")));
-        return document.member("wireLength")
-                .map(length -> Payload.partial(content, mediaType,
-                        number(length, "wireLength").longValueExact()))
-                .orElseGet(() -> Payload.of(content, mediaType));
+        return new Payload(content, mediaType, document.member("wireLength")
+                .map(length -> number(length, "wireLength").longValueExact()));
     }
 
     /**

--- a/restest-store/src/main/java/io/restest/store/Json.java
+++ b/restest-store/src/main/java/io/restest/store/Json.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.store;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import io.restest.core.json.JsonValue;
+import io.restest.core.store.InteractionStoreException;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Turns RESTest's own idea of a JSON value into text, and text back into it.
+ *
+ * <p>RESTest keeps JSON in types of its own rather than a library's, so that everything built on top
+ * of it - a generator, an oracle, a report - depends on nothing but RESTest. That choice stops at the
+ * edge of the disk: writing it out and reading it back needs a real JSON reader and writer, and the
+ * escaping and number rules are exactly the sort of thing that looks easy and is not. So this is a
+ * thin adapter over a library that does it properly, and it lives here, next to the disk, rather than
+ * anywhere a user of RESTest would meet it.
+ *
+ * <p>Numbers keep their exact written form, so an identifier with twenty digits comes back as itself
+ * rather than as the nearest number a computer could hold.
+ */
+final class Json {
+
+    private static final JsonFactory FACTORY = JsonFactory.builder().build();
+
+    private Json() {
+    }
+
+    /** The value as compact JSON text, on one line. */
+    static String write(JsonValue value) {
+        Objects.requireNonNull(value, "value");
+        StringWriter text = new StringWriter();
+        try (JsonGenerator out = FACTORY.createGenerator(text)) {
+            writeValue(out, value);
+        } catch (IOException e) {
+            throw new InteractionStoreException("This value could not be written as JSON", e);
+        }
+        return text.toString();
+    }
+
+    /** The value the text describes. */
+    static JsonValue read(String text) {
+        Objects.requireNonNull(text, "text");
+        try (JsonParser in = FACTORY.createParser(text)) {
+            if (in.nextToken() == null) {
+                throw new InteractionStoreException("Empty text where a JSON value was expected");
+            }
+            return readValue(in);
+        } catch (IOException e) {
+            throw new InteractionStoreException(
+                    "This is not the JSON it was recorded as: " + e.getMessage(), e);
+        }
+    }
+
+    private static void writeValue(JsonGenerator out, JsonValue value) throws IOException {
+        switch (value) {
+            case JsonValue.JsonNull ignored -> out.writeNull();
+            case JsonValue.JsonBoolean bool -> out.writeBoolean(bool.value());
+            case JsonValue.JsonNumber number -> out.writeNumber(number.value());
+            case JsonValue.JsonString string -> out.writeString(string.value());
+            case JsonValue.JsonArray array -> {
+                out.writeStartArray();
+                for (JsonValue element : array.elements()) {
+                    writeValue(out, element);
+                }
+                out.writeEndArray();
+            }
+            case JsonValue.JsonObject object -> {
+                out.writeStartObject();
+                for (Map.Entry<String, JsonValue> member : object.members().entrySet()) {
+                    out.writeFieldName(member.getKey());
+                    writeValue(out, member.getValue());
+                }
+                out.writeEndObject();
+            }
+        }
+    }
+
+    private static JsonValue readValue(JsonParser in) throws IOException {
+        JsonToken token = in.currentToken();
+        return switch (token) {
+            case VALUE_NULL -> JsonValue.NULL;
+            case VALUE_TRUE -> JsonValue.TRUE;
+            case VALUE_FALSE -> JsonValue.FALSE;
+            case VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT ->
+                    JsonValue.of(new BigDecimal(in.getText()));
+            case VALUE_STRING -> JsonValue.of(in.getText());
+            case START_ARRAY -> readArray(in);
+            case START_OBJECT -> readObject(in);
+            case null, default -> throw new InteractionStoreException(
+                    "A JSON value cannot start with " + token);
+        };
+    }
+
+    private static JsonValue readArray(JsonParser in) throws IOException {
+        List<JsonValue> elements = new ArrayList<>();
+        while (in.nextToken() != JsonToken.END_ARRAY) {
+            elements.add(readValue(in));
+        }
+        return JsonValue.array(elements);
+    }
+
+    private static JsonValue readObject(JsonParser in) throws IOException {
+        Map<String, JsonValue> members = new LinkedHashMap<>();
+        while (in.nextToken() != JsonToken.END_OBJECT) {
+            String name = in.currentName();
+            in.nextToken();
+            members.put(name, readValue(in));
+        }
+        return JsonValue.object(members);
+    }
+}

--- a/restest-store/src/main/java/io/restest/store/Json.java
+++ b/restest-store/src/main/java/io/restest/store/Json.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import io.restest.core.json.JsonValue;
 import io.restest.core.store.InteractionStoreException;
 import java.io.IOException;
@@ -41,20 +42,42 @@ import java.util.Objects;
  * anywhere a user of RESTest would meet it.
  *
  * <p>Numbers keep their exact written form, so an identifier with twenty digits comes back as itself
- * rather than as the nearest number a computer could hold.
+ * rather than as the nearest number a computer could hold - and they are written the way people
+ * write them. A status code of 200 is stored as {@code 200}: the obvious-looking shortcut here
+ * produces {@code 2E+2}, which is the same number and is not what anybody reading a stored run
+ * expects to see.
  */
-final class Json {
+public final class Json {
 
-    private static final JsonFactory FACTORY = JsonFactory.builder().build();
+    /**
+     * The reader refuses very long pieces of text by default, as a defence against hostile input.
+     * That defence is aimed at data arriving from strangers; here the text is a run this tool wrote
+     * itself moments earlier, and the size of a reply body is the user's own setting to make. Left at
+     * the default, a run that kept a twenty-megabyte reply would be written happily and then be
+     * unreadable for ever.
+     */
+    private static final JsonFactory FACTORY = JsonFactory.builder()
+            .streamReadConstraints(StreamReadConstraints.builder()
+                    .maxStringLength(Integer.MAX_VALUE)
+                    .maxNumberLength(Integer.MAX_VALUE)
+                    .maxNestingDepth(10_000)
+                    .build())
+            .build();
 
     private Json() {
     }
 
-    /** The value as compact JSON text, on one line. */
-    static String write(JsonValue value) {
+    /**
+     * The value as compact JSON text, on one line.
+     *
+     * @param value what to write
+     * @return the JSON text
+     */
+    public static String write(JsonValue value) {
         Objects.requireNonNull(value, "value");
         StringWriter text = new StringWriter();
         try (JsonGenerator out = FACTORY.createGenerator(text)) {
+            out.enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);
             writeValue(out, value);
         } catch (IOException e) {
             throw new InteractionStoreException("This value could not be written as JSON", e);
@@ -62,8 +85,13 @@ final class Json {
         return text.toString();
     }
 
-    /** The value the text describes. */
-    static JsonValue read(String text) {
+    /**
+     * The value the text describes.
+     *
+     * @param text JSON text, as {@link #write} produces
+     * @return the value it describes
+     */
+    public static JsonValue read(String text) {
         Objects.requireNonNull(text, "text");
         try (JsonParser in = FACTORY.createParser(text)) {
             if (in.nextToken() == null) {
@@ -72,7 +100,7 @@ final class Json {
             return readValue(in);
         } catch (IOException e) {
             throw new InteractionStoreException(
-                    "This is not the JSON it was recorded as: " + e.getMessage(), e);
+                    "Stored JSON could not be read back: " + e.getMessage(), e);
         }
     }
 

--- a/restest-store/src/main/java/io/restest/store/SqliteInteractionStore.java
+++ b/restest-store/src/main/java/io/restest/store/SqliteInteractionStore.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.store;
+
+import io.restest.core.execution.Interaction;
+import io.restest.core.execution.InteractionId;
+import io.restest.core.execution.InteractionOutcome;
+import io.restest.core.store.InteractionQuery;
+import io.restest.core.store.InteractionStore;
+import io.restest.core.store.InteractionStoreException;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+import org.sqlite.SQLiteConfig;
+import org.sqlite.SQLiteDataSource;
+
+/**
+ * Keeps everything a run did in a single SQLite file, and answers questions about it afterwards.
+ *
+ * <p>SQLite is a database that lives in one ordinary file. That matters here for three reasons: a
+ * finished run is one file that can be copied, attached to a bug report or kept as evidence; asking
+ * it a question does not mean reading the whole run back into memory, so a run of a hundred thousand
+ * requests can still be asked "which of these returned a server error" instantly; and the file can be
+ * opened by tools that have never heard of RESTest - the {@code sqlite3} command, a spreadsheet, a
+ * notebook - so nobody is locked in to our reports.
+ *
+ * <p>Each interaction is one row. The handful of facts anybody filters on - which operation, which
+ * status code, how it ended - are their own columns, with an index each. The interaction itself sits
+ * beside them as a JSON document, which is why adding a field to what RESTest records does not mean a
+ * new column and a migration for every run ever stored, and why the stored run stays readable by
+ * anything that reads JSON.
+ *
+ * <p>The file is written in a mode that lets somebody read a run while it is still going on, which is
+ * what a live dashboard or an impatient person with {@code sqlite3} will want.
+ */
+public final class SqliteInteractionStore implements InteractionStore {
+
+    private static final String SCHEMA = """
+            CREATE TABLE IF NOT EXISTS interaction (
+                id            TEXT PRIMARY KEY,
+                test_case     TEXT    NOT NULL,
+                operation     TEXT    NOT NULL,
+                method        TEXT    NOT NULL,
+                url           TEXT    NOT NULL,
+                status_code   INTEGER,
+                outcome       TEXT    NOT NULL,
+                sent_at       TEXT    NOT NULL,
+                elapsed_nanos INTEGER NOT NULL,
+                document      TEXT    NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS interaction_by_operation ON interaction (operation);
+            CREATE INDEX IF NOT EXISTS interaction_by_status ON interaction (status_code);
+            CREATE INDEX IF NOT EXISTS interaction_by_outcome ON interaction (outcome);
+            """;
+
+    private static final String INSERT = """
+            INSERT OR REPLACE INTO interaction
+                (id, test_case, operation, method, url, status_code, outcome, sent_at,
+                 elapsed_nanos, document)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """;
+
+    /** Oldest first, and the row number settles the order of two requests sent in the same instant. */
+    private static final String ORDER = " ORDER BY sent_at, rowid";
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final String describedAs;
+    private final Connection connection;
+    private boolean closed;
+
+    private SqliteInteractionStore(String url, String describedAs) {
+        this.describedAs = describedAs;
+        SQLiteConfig settings = new SQLiteConfig();
+        // Lets a reader look at the run while it is still being written.
+        settings.setJournalMode(SQLiteConfig.JournalMode.WAL);
+        settings.setSynchronous(SQLiteConfig.SynchronousMode.NORMAL);
+        SQLiteDataSource source = new SQLiteDataSource(settings);
+        source.setUrl(url);
+        try {
+            this.connection = source.getConnection();
+            try (Statement schema = connection.createStatement()) {
+                for (String statement : SCHEMA.split(";")) {
+                    if (!statement.isBlank()) {
+                        schema.execute(statement);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new InteractionStoreException("The run's evidence could not be opened at "
+                    + describedAs + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * A store kept in the given file, created if it is not there and added to if it is.
+     *
+     * @param file where the run is kept. Its directory must exist
+     * @return the store
+     */
+    public static SqliteInteractionStore at(Path file) {
+        Objects.requireNonNull(file, "file");
+        return new SqliteInteractionStore("jdbc:sqlite:" + file.toAbsolutePath(), file.toString());
+    }
+
+    /**
+     * A store that exists only while the program runs and leaves nothing behind.
+     *
+     * <p>For a test, or for a program using RESTest as a library that wants to ask questions about a
+     * run without keeping it. Everything else behaves identically, which is the point: nothing has to
+     * be written differently to be tried this way first.
+     *
+     * @return the store
+     */
+    public static SqliteInteractionStore inMemory() {
+        return new SqliteInteractionStore("jdbc:sqlite::memory:", "memory");
+    }
+
+    @Override
+    public void record(Interaction interaction) {
+        Objects.requireNonNull(interaction, "interaction");
+        String document = Json.write(InteractionDocument.of(interaction));
+        lock.lock();
+        try (PreparedStatement insert = statement(INSERT)) {
+            insert.setString(1, interaction.id().value());
+            insert.setString(2, interaction.testCase().id().value());
+            insert.setString(3, interaction.testCase().operation().value());
+            insert.setString(4, interaction.request().method().name());
+            insert.setString(5, interaction.request().url());
+            Optional<Integer> status = statusOf(interaction);
+            if (status.isPresent()) {
+                insert.setInt(6, status.get());
+            } else {
+                insert.setNull(6, java.sql.Types.INTEGER);
+            }
+            insert.setString(7, outcomeOf(interaction));
+            insert.setString(8, interaction.sentAt().toString());
+            insert.setLong(9, interaction.elapsed().toNanos());
+            insert.setString(10, document);
+            insert.executeUpdate();
+        } catch (SQLException e) {
+            throw failure("write an interaction to", e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public List<Interaction> find(InteractionQuery query) {
+        Objects.requireNonNull(query, "query");
+        List<Object> values = new ArrayList<>();
+        String sql = "SELECT document FROM interaction" + where(query, values) + ORDER
+                + query.limit().map(limit -> " LIMIT " + limit).orElse("");
+        lock.lock();
+        try (PreparedStatement select = statement(sql)) {
+            bind(select, values);
+            try (ResultSet rows = select.executeQuery()) {
+                List<Interaction> found = new ArrayList<>();
+                while (rows.next()) {
+                    found.add(InteractionDocument.toInteraction(Json.read(rows.getString(1))));
+                }
+                return List.copyOf(found);
+            }
+        } catch (SQLException e) {
+            throw failure("read interactions from", e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>A limit on the question is about how many interactions the caller wants handed back, not
+     * about how many there are, so counting ignores it: asking "how many server errors, at most ten"
+     * answers how many there were.
+     */
+    @Override
+    public long count(InteractionQuery query) {
+        Objects.requireNonNull(query, "query");
+        List<Object> values = new ArrayList<>();
+        String sql = "SELECT COUNT(*) FROM interaction" + where(query, values);
+        lock.lock();
+        try (PreparedStatement select = statement(sql)) {
+            bind(select, values);
+            try (ResultSet rows = select.executeQuery()) {
+                return rows.next() ? rows.getLong(1) : 0;
+            }
+        } catch (SQLException e) {
+            throw failure("count interactions in", e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public Optional<Interaction> byId(InteractionId id) {
+        Objects.requireNonNull(id, "id");
+        lock.lock();
+        try (PreparedStatement select =
+                statement("SELECT document FROM interaction WHERE id = ?")) {
+            select.setString(1, id.value());
+            try (ResultSet rows = select.executeQuery()) {
+                return rows.next()
+                        ? Optional.of(
+                                InteractionDocument.toInteraction(Json.read(rows.getString(1))))
+                        : Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw failure("read an interaction from", e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void close() {
+        lock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            connection.close();
+        } catch (SQLException e) {
+            throw failure("close", e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Where the run is kept, for a report or an error message that has to name it. */
+    @Override
+    public String toString() {
+        return "SqliteInteractionStore[" + describedAs + "]";
+    }
+
+    private String where(InteractionQuery query, List<Object> values) {
+        List<String> conditions = new ArrayList<>();
+        query.operation().ifPresent(operation -> {
+            conditions.add("operation = ?");
+            values.add(operation.value());
+        });
+        query.statusCode().ifPresent(status -> {
+            conditions.add("status_code = ?");
+            values.add(status);
+        });
+        query.statusClass().ifPresent(firstDigit -> {
+            conditions.add("status_code >= ? AND status_code < ?");
+            values.add(firstDigit * 100);
+            values.add((firstDigit + 1) * 100);
+        });
+        query.outcome().ifPresent(outcome -> {
+            conditions.add("outcome = ?");
+            values.add(name(outcome));
+        });
+        return conditions.isEmpty() ? "" : " WHERE " + String.join(" AND ", conditions);
+    }
+
+    private static void bind(PreparedStatement statement, List<Object> values) throws SQLException {
+        for (int i = 0; i < values.size(); i++) {
+            statement.setObject(i + 1, values.get(i));
+        }
+    }
+
+    private PreparedStatement statement(String sql) throws SQLException {
+        if (closed) {
+            throw new InteractionStoreException(
+                    "This store is closed, so " + describedAs + " can no longer be used");
+        }
+        return connection.prepareStatement(sql);
+    }
+
+    private static Optional<Integer> statusOf(Interaction interaction) {
+        return switch (interaction.outcome()) {
+            case InteractionOutcome.Answered answered ->
+                    Optional.of(answered.response().statusCode());
+            case InteractionOutcome.MalformedResponse malformed ->
+                    malformed.statusLine().map(line -> line.statusCode());
+            case InteractionOutcome.TransportFailure ignored -> Optional.empty();
+        };
+    }
+
+    private static String outcomeOf(Interaction interaction) {
+        return switch (interaction.outcome()) {
+            case InteractionOutcome.Answered ignored -> name(InteractionQuery.Outcome.ANSWERED);
+            case InteractionOutcome.MalformedResponse ignored ->
+                    name(InteractionQuery.Outcome.MALFORMED);
+            case InteractionOutcome.TransportFailure ignored ->
+                    name(InteractionQuery.Outcome.FAILED);
+        };
+    }
+
+    /** The word stored in the row, kept lowercase so the file reads plainly outside RESTest. */
+    private static String name(InteractionQuery.Outcome outcome) {
+        return outcome.name().toLowerCase(java.util.Locale.ROOT);
+    }
+
+    private InteractionStoreException failure(String what, SQLException cause) {
+        return new InteractionStoreException(
+                "Could not " + what + " the run's evidence at " + describedAs + ": "
+                        + cause.getMessage(), cause);
+    }
+}

--- a/restest-store/src/main/java/io/restest/store/SqliteInteractionStore.java
+++ b/restest-store/src/main/java/io/restest/store/SqliteInteractionStore.java
@@ -52,11 +52,24 @@ import org.sqlite.SQLiteDataSource;
  * anything that reads JSON.
  *
  * <p>The file is written in a mode that lets somebody read a run while it is still going on, which is
- * what a live dashboard or an impatient person with {@code sqlite3} will want.
+ * what a live dashboard or an impatient person with {@code sqlite3} will want. While a run is in
+ * progress that mode keeps two working files beside the main one, named after it and ending in
+ * {@code -wal} and {@code -shm}; closing the store folds them back in and deletes them. A run that is
+ * interrupted before the store is closed leaves all three, and all three together are the evidence -
+ * copying only the main file out of an interrupted run would leave the most recent interactions
+ * behind.
  */
 public final class SqliteInteractionStore implements InteractionStore {
 
-    private static final String SCHEMA = """
+    /**
+     * Stamped into every file this version writes. A later version that changes the shape of the
+     * table raises it, and this one then says plainly that the run was written by something newer
+     * rather than failing later with a complaint about a missing column.
+     */
+    private static final int LAYOUT = 1;
+
+    private static final List<String> SCHEMA = List.of(
+            """
             CREATE TABLE IF NOT EXISTS interaction (
                 id            TEXT PRIMARY KEY,
                 test_case     TEXT    NOT NULL,
@@ -66,23 +79,31 @@ public final class SqliteInteractionStore implements InteractionStore {
                 status_code   INTEGER,
                 outcome       TEXT    NOT NULL,
                 sent_at       TEXT    NOT NULL,
+                sent_at_nanos INTEGER NOT NULL,
                 elapsed_nanos INTEGER NOT NULL,
                 document      TEXT    NOT NULL
-            );
-            CREATE INDEX IF NOT EXISTS interaction_by_operation ON interaction (operation);
-            CREATE INDEX IF NOT EXISTS interaction_by_status ON interaction (status_code);
-            CREATE INDEX IF NOT EXISTS interaction_by_outcome ON interaction (outcome);
-            """;
+            )""",
+            "CREATE INDEX IF NOT EXISTS interaction_by_operation ON interaction (operation)",
+            "CREATE INDEX IF NOT EXISTS interaction_by_status ON interaction (status_code)",
+            "CREATE INDEX IF NOT EXISTS interaction_by_outcome ON interaction (outcome)",
+            "CREATE INDEX IF NOT EXISTS interaction_in_order ON interaction (sent_at_nanos)");
 
     private static final String INSERT = """
             INSERT OR REPLACE INTO interaction
                 (id, test_case, operation, method, url, status_code, outcome, sent_at,
-                 elapsed_nanos, document)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 sent_at_nanos, elapsed_nanos, document)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """;
 
-    /** Oldest first, and the row number settles the order of two requests sent in the same instant. */
-    private static final String ORDER = " ORDER BY sent_at, rowid";
+    /**
+     * Oldest first.
+     *
+     * <p>Ordered by the moment the request went out, counted as a number rather than compared as
+     * written text. Written out, an instant prints however many decimals it needs - {@code 12:00:00Z}
+     * and {@code 12:00:00.5Z} and {@code 12:00:00.123456Z} - and comparing those as text puts them in
+     * an order that has nothing to do with time. The row number settles the rare tie.
+     */
+    private static final String ORDER = " ORDER BY sent_at_nanos, rowid";
 
     private final ReentrantLock lock = new ReentrantLock();
     private final String describedAs;
@@ -97,18 +118,62 @@ public final class SqliteInteractionStore implements InteractionStore {
         settings.setSynchronous(SQLiteConfig.SynchronousMode.NORMAL);
         SQLiteDataSource source = new SQLiteDataSource(settings);
         source.setUrl(url);
+        Connection opened = null;
         try {
-            this.connection = source.getConnection();
-            try (Statement schema = connection.createStatement()) {
-                for (String statement : SCHEMA.split(";")) {
-                    if (!statement.isBlank()) {
-                        schema.execute(statement);
-                    }
-                }
+            opened = source.getConnection();
+            prepare(opened, describedAs);
+            this.connection = opened;
+        } catch (SQLException | RuntimeException e) {
+            // Without this the failed connection would be left open and unreachable, and a program
+            // that opens one store per API under test would run out of files it is allowed to hold.
+            closeQuietly(opened);
+            if (e instanceof InteractionStoreException already) {
+                throw already;
             }
-        } catch (SQLException e) {
             throw new InteractionStoreException("The run's evidence could not be opened at "
                     + describedAs + ": " + e.getMessage(), e);
+        }
+    }
+
+    private static void prepare(Connection connection, String describedAs) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            int written;
+            try (ResultSet rows = statement.executeQuery("PRAGMA user_version")) {
+                written = rows.next() ? rows.getInt(1) : 0;
+            }
+            if (written > LAYOUT) {
+                throw new InteractionStoreException("The run at " + describedAs + " was written by "
+                        + "a newer version of RESTest (its layout is " + written + ", this version "
+                        + "knows " + LAYOUT + "), so it cannot be read here");
+            }
+            for (String schema : SCHEMA) {
+                statement.execute(schema);
+            }
+            statement.execute("PRAGMA user_version = " + LAYOUT);
+        }
+    }
+
+    private static void closeQuietly(Connection connection) {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (SQLException beyondHelp) {
+                // Already failing; the original failure is the one worth reporting.
+            }
+        }
+    }
+
+    /**
+     * The moment a request went out, as a plain count of nanoseconds, so that rows can be put in the
+     * order they happened. Clamped rather than refused for a date far outside any real run: a
+     * nonsensical timestamp is not a reason to lose the interaction it belongs to.
+     */
+    private static long instantAsNumber(java.time.Instant instant) {
+        try {
+            return Math.addExact(
+                    Math.multiplyExact(instant.getEpochSecond(), 1_000_000_000L), instant.getNano());
+        } catch (ArithmeticException farFuture) {
+            return instant.isAfter(java.time.Instant.EPOCH) ? Long.MAX_VALUE : Long.MIN_VALUE;
         }
     }
 
@@ -155,8 +220,9 @@ public final class SqliteInteractionStore implements InteractionStore {
             }
             insert.setString(7, outcomeOf(interaction));
             insert.setString(8, interaction.sentAt().toString());
-            insert.setLong(9, interaction.elapsed().toNanos());
-            insert.setString(10, document);
+            insert.setLong(9, instantAsNumber(interaction.sentAt()));
+            insert.setLong(10, interaction.elapsed().toNanos());
+            insert.setString(11, document);
             insert.executeUpdate();
         } catch (SQLException e) {
             throw failure("write an interaction to", e);
@@ -169,22 +235,40 @@ public final class SqliteInteractionStore implements InteractionStore {
     public List<Interaction> find(InteractionQuery query) {
         Objects.requireNonNull(query, "query");
         List<Object> values = new ArrayList<>();
-        String sql = "SELECT document FROM interaction" + where(query, values) + ORDER
+        String sql = "SELECT id, document FROM interaction" + where(query, values) + ORDER
                 + query.limit().map(limit -> " LIMIT " + limit).orElse("");
+        // The rows are fetched while holding the lock and turned back into interactions afterwards.
+        // Rebuilding a hundred thousand interactions takes a while, and nothing should have to wait
+        // to record what an API just answered because somebody is reading the run at the same time.
+        List<String[]> rowsRead = new ArrayList<>();
         lock.lock();
         try (PreparedStatement select = statement(sql)) {
             bind(select, values);
             try (ResultSet rows = select.executeQuery()) {
-                List<Interaction> found = new ArrayList<>();
                 while (rows.next()) {
-                    found.add(InteractionDocument.toInteraction(Json.read(rows.getString(1))));
+                    rowsRead.add(new String[] {rows.getString(1), rows.getString(2)});
                 }
-                return List.copyOf(found);
             }
         } catch (SQLException e) {
             throw failure("read interactions from", e);
         } finally {
             lock.unlock();
+        }
+        return rowsRead.stream().map(row -> read(row[0], row[1])).toList();
+    }
+
+    /**
+     * One stored row as an interaction again, saying which row it was if it cannot be read. Without
+     * the identifier, a single damaged interaction in a run of thousands is a complaint nobody can
+     * act on.
+     */
+    private static Interaction read(String id, String document) {
+        try {
+            return InteractionDocument.toInteraction(Json.read(document));
+        } catch (InteractionStoreException e) {
+            throw new InteractionStoreException(
+                    "The interaction recorded as " + id + " could not be read back: "
+                            + e.getMessage(), e);
         }
     }
 
@@ -222,8 +306,7 @@ public final class SqliteInteractionStore implements InteractionStore {
             select.setString(1, id.value());
             try (ResultSet rows = select.executeQuery()) {
                 return rows.next()
-                        ? Optional.of(
-                                InteractionDocument.toInteraction(Json.read(rows.getString(1))))
+                        ? Optional.of(read(id.value(), rows.getString(1)))
                         : Optional.empty();
             }
         } catch (SQLException e) {

--- a/restest-store/src/main/java/module-info.java
+++ b/restest-store/src/main/java/module-info.java
@@ -1,3 +1,38 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Where a run's evidence is kept: every request RESTest sent, every reply it got back, and enough
+ * about each one to look at it again long after the run ended.
+ *
+ * <p>A run is kept in a single SQLite file - a database that is one ordinary file rather than a
+ * server somebody has to install - so a finished run can be copied, attached to a bug report, or
+ * opened by any tool that reads SQLite. Everything else in RESTest asks this module through the
+ * small interface in {@code io.restest.core.store} and never learns that a database is involved.
+ *
+ * <p>Two third-party libraries are needed and both are confined here. One is the SQLite driver. The
+ * other reads and writes JSON text: RESTest keeps JSON in types of its own so that nothing built on
+ * it depends on a JSON library, and this module is the one place that has to turn those types into
+ * text on a disk and back again.
+ */
 module io.restest.store {
     requires io.restest.core;
+    requires java.sql;
+    requires org.xerial.sqlitejdbc;
+    requires com.fasterxml.jackson.core;
+
+    exports io.restest.store;
 }

--- a/restest-store/src/test/java/io/restest/store/Interactions.java
+++ b/restest-store/src/test/java/io/restest/store/Interactions.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.store;
+
+import io.restest.core.execution.BodyValue;
+import io.restest.core.execution.Header;
+import io.restest.core.execution.HttpRequestRecord;
+import io.restest.core.execution.HttpResponseRecord;
+import io.restest.core.execution.Interaction;
+import io.restest.core.execution.Payload;
+import io.restest.core.execution.StatusLine;
+import io.restest.core.execution.TestCase;
+import io.restest.core.execution.ValueOrigin;
+import io.restest.core.json.JsonValue;
+import io.restest.core.model.HttpMethod;
+import io.restest.core.model.OperationId;
+import io.restest.core.model.ParameterLocation;
+import io.restest.core.execution.ParameterValue;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Interactions built by hand for these tests, standing in for the ones a real run produces. The
+ * generator that invents them and the engine that sends them are tested elsewhere; what matters here
+ * is only that whatever is put in comes back out.
+ */
+final class Interactions {
+
+    static final Instant NOON = Instant.parse("2026-09-12T12:00:00Z");
+
+    private Interactions() {
+    }
+
+    /** A plain answered request: the ordinary case, and the one most rows will be. */
+    static Interaction answered(String operation, int statusCode) {
+        return answered(operation, statusCode, NOON);
+    }
+
+    static Interaction answered(String operation, int statusCode, Instant sentAt) {
+        return Interaction.answered(
+                testCase(operation),
+                HttpRequestRecord.of(HttpMethod.GET, "http://localhost:8080/widgets"),
+                new HttpResponseRecord(StatusLine.of(statusCode), List.of(), Optional.empty()),
+                sentAt,
+                Duration.ofMillis(42));
+    }
+
+    /** An attempt that never got an answer. */
+    static Interaction failed(String operation) {
+        return Interaction.transportFailure(
+                testCase(operation),
+                HttpRequestRecord.of(HttpMethod.GET, "http://localhost:8080/widgets"),
+                "ConnectException: connection refused",
+                NOON,
+                Duration.ofMillis(7));
+    }
+
+    /** A reply that started correctly and stopped halfway. */
+    static Interaction malformed(String operation, int statusCode) {
+        return Interaction.malformedResponse(
+                testCase(operation),
+                HttpRequestRecord.of(HttpMethod.GET, "http://localhost:8080/widgets"),
+                "the reply stopped after 4 bytes: SocketException",
+                Optional.of(new StatusLine(statusCode, Optional.of("OK"), Optional.of("http/1.1"))),
+                List.of(Header.of("Content-Type", "application/json")),
+                Optional.of(Payload.partial("half".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+                        "application/json", 100)),
+                NOON,
+                Duration.ofMillis(13));
+    }
+
+    /**
+     * Everything a single interaction can carry at once: repeated headers, a body that was sent, a
+     * reply that was truncated, parameter values from all three kinds of source.
+     */
+    static Interaction elaborate() {
+        TestCase testCase = new TestCase(
+                io.restest.core.execution.TestCaseId.of("test-case-1"),
+                OperationId.of("POST /widgets"),
+                List.of(
+                        ParameterValue.of("widgetId", ParameterLocation.PATH,
+                                JsonValue.of("w-1"), ValueOrigin.DECLARED),
+                        ParameterValue.of("verbose", ParameterLocation.QUERY,
+                                JsonValue.TRUE, new ValueOrigin.Generated("random")),
+                        ParameterValue.of("X-Trace", ParameterLocation.HEADER,
+                                JsonValue.of(new java.math.BigDecimal("90071992547409911")),
+                                new ValueOrigin.Derived(
+                                        io.restest.core.execution.InteractionId.of("earlier-one"),
+                                        "the identifier the create call returned"))),
+                Optional.of(new BodyValue("application/json",
+                        JsonValue.object(new java.util.LinkedHashMap<>(java.util.Map.of(
+                                "name", JsonValue.of("a widget")))),
+                        new ValueOrigin.Generated("random"))));
+
+        HttpRequestRecord request = new HttpRequestRecord(HttpMethod.POST,
+                "http://localhost:8080/widgets?verbose=true",
+                List.of(Header.of("Accept", "application/json"),
+                        Header.of("Accept", "text/plain"),
+                        Header.of("Content-Type", "application/json")),
+                Optional.of(Payload.text("{\"name\":\"a widget\"}", "application/json")));
+
+        HttpResponseRecord response = new HttpResponseRecord(
+                new StatusLine(201, Optional.of("Created"), Optional.of("http/1.1")),
+                List.of(Header.of("Location", "/widgets/w-1"),
+                        Header.of("Set-Cookie", "a=1"),
+                        Header.of("Set-Cookie", "b=2")),
+                Optional.of(Payload.partial("{\"id\":\"w-1\"".getBytes(
+                        java.nio.charset.StandardCharsets.UTF_8), "application/json", 4096)));
+
+        return Interaction.answered(testCase, request, response, NOON, Duration.ofMillis(123));
+    }
+
+    /** A reply that is not text at all, so it cannot be stored as text without changing it. */
+    static Interaction withBinaryReply() {
+        byte[] notText = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0, 0x00, 0x10};
+        return Interaction.answered(
+                testCase("GET /image"),
+                HttpRequestRecord.of(HttpMethod.GET, "http://localhost:8080/image"),
+                new HttpResponseRecord(StatusLine.of(200), List.of(),
+                        Optional.of(Payload.of(notText, "image/jpeg"))),
+                NOON,
+                Duration.ofMillis(5));
+    }
+
+    static TestCase testCase(String operation) {
+        return TestCase.of(OperationId.of(operation), List.of());
+    }
+}

--- a/restest-store/src/test/java/io/restest/store/JsonTest.java
+++ b/restest-store/src/test/java/io/restest/store/JsonTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.restest.core.json.JsonValue;
+import io.restest.core.store.InteractionStoreException;
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Whatever RESTest can hold as a JSON value has to survive being written to a file and read back,
+ * because a stored run is only useful if it is the run that happened.
+ */
+class JsonTest {
+
+    static List<JsonValue> values() {
+        return List.of(
+                JsonValue.NULL,
+                JsonValue.TRUE,
+                JsonValue.FALSE,
+                JsonValue.of(""),
+                JsonValue.of("a widget"),
+                JsonValue.of("quotes \" backslashes \\ newlines \n tabs \t"),
+                JsonValue.of("café — éàü, emoji 🐛"),
+                JsonValue.of(0),
+                JsonValue.of(-1),
+                JsonValue.of(Long.MAX_VALUE),
+                JsonValue.of(new BigDecimal("0.1")),
+                JsonValue.of(new BigDecimal("-12345678901234567890.0987654321")),
+                JsonValue.array(),
+                JsonValue.array(JsonValue.of(1), JsonValue.NULL, JsonValue.of("two")),
+                JsonValue.object(Map.of()),
+                nested());
+    }
+
+    private static JsonValue nested() {
+        Map<String, JsonValue> inner = new LinkedHashMap<>();
+        inner.put("id", JsonValue.of("w-1"));
+        inner.put("tags", JsonValue.array(JsonValue.of("a"), JsonValue.of("b")));
+        Map<String, JsonValue> outer = new LinkedHashMap<>();
+        outer.put("widget", JsonValue.object(inner));
+        outer.put("count", JsonValue.of(2));
+        outer.put("missing", JsonValue.NULL);
+        return JsonValue.object(outer);
+    }
+
+    @ParameterizedTest
+    @MethodSource("values")
+    @DisplayName("every kind of value comes back as itself")
+    void a_value_survives_being_written_and_read(JsonValue value) {
+        assertThat(Json.read(Json.write(value))).isEqualTo(value);
+    }
+
+    @Test
+    @DisplayName("a number too large for a computer's usual arithmetic keeps every digit")
+    void a_large_number_is_not_rounded() {
+        JsonValue identifier = JsonValue.of(new BigDecimal("90071992547409911"));
+
+        JsonValue.JsonNumber read = (JsonValue.JsonNumber) Json.read(Json.write(identifier));
+
+        assertThat(read.value().toPlainString())
+                .describedAs("an identifier read back as a slightly different number would make a "
+                        + "stored run describe a request nobody sent")
+                .isEqualTo("90071992547409911");
+    }
+
+    @Test
+    @DisplayName("the order an object's members were written in is the order they come back")
+    void member_order_is_kept() {
+        assertThat(((JsonValue.JsonObject) Json.read(Json.write(nested()))).members().keySet())
+                .containsExactly("widget", "count", "missing");
+    }
+
+    @Test
+    @DisplayName("text that is not JSON at all is reported, not guessed at")
+    void broken_text_is_reported() {
+        assertThatExceptionOfType(InteractionStoreException.class)
+                .isThrownBy(() -> Json.read("{\"unfinished\": "));
+        assertThatExceptionOfType(InteractionStoreException.class)
+                .isThrownBy(() -> Json.read(""))
+                .withMessageContaining("Empty");
+    }
+}

--- a/restest-store/src/test/java/io/restest/store/SqliteInteractionStoreTest.java
+++ b/restest-store/src/test/java/io/restest/store/SqliteInteractionStoreTest.java
@@ -165,6 +165,127 @@ class SqliteInteractionStoreTest {
     }
 
     @Test
+    @DisplayName("requests sent within the same second are still ordered by when they went out")
+    void the_order_holds_for_requests_a_fraction_of_a_second_apart() {
+        // A real clock produces instants that print with however many decimals they need, and
+        // comparing those as written text puts them in an order that has nothing to do with time.
+        Interaction first = Interactions.answered("GET /first", 200, Interactions.NOON);
+        Interaction second = Interactions.answered("GET /second", 200,
+                Interactions.NOON.plusMillis(500));
+        Interaction third = Interactions.answered("GET /third", 200,
+                Interactions.NOON.plusNanos(700_123_456));
+
+        store.record(third);
+        store.record(first);
+        store.record(second);
+
+        assertThat(store.find(InteractionQuery.all()))
+                .extracting(interaction -> interaction.testCase().operation().value())
+                .containsExactly("GET /first", "GET /second", "GET /third");
+    }
+
+    @Test
+    @DisplayName("a run kept alongside is still readable, and a newer layout says so plainly")
+    void a_run_written_by_a_newer_version_is_refused_clearly() throws Exception {
+        Path file = directory.resolve("from-the-future.sqlite");
+        try (SqliteInteractionStore writing = SqliteInteractionStore.at(file)) {
+            writing.record(Interactions.answered("GET /widgets", 200));
+        }
+        execute(file, "PRAGMA user_version = 99");
+
+        assertThatExceptionOfType(InteractionStoreException.class)
+                .isThrownBy(() -> SqliteInteractionStore.at(file))
+                .withMessageContaining("newer version");
+    }
+
+    @Test
+    @DisplayName("a stored interaction that has been damaged is reported, not thrown at the reader")
+    void a_damaged_interaction_is_reported_as_one() throws Exception {
+        Path file = directory.resolve("damaged.sqlite");
+        Interaction stored = Interactions.answered("GET /widgets", 200);
+        try (SqliteInteractionStore writing = SqliteInteractionStore.at(file)) {
+            writing.record(stored);
+        }
+        execute(file, "UPDATE interaction SET document = "
+                + "json_set(document, '$.sentAt', 'not a time')");
+
+        try (SqliteInteractionStore reading = SqliteInteractionStore.at(file)) {
+            assertThatExceptionOfType(InteractionStoreException.class)
+                    .describedAs("the interface promises this is the only exception it throws")
+                    .isThrownBy(() -> reading.find(InteractionQuery.all()))
+                    .withMessageContaining("could not be read back");
+        }
+    }
+
+    @Test
+    @DisplayName("a reply that named its length and was not cut short keeps that length")
+    void a_body_that_knows_its_length_keeps_it_even_when_nothing_was_dropped() {
+        byte[] content = "12345".getBytes(StandardCharsets.UTF_8);
+        Interaction stored = Interaction.answered(
+                Interactions.testCase("GET /widgets"),
+                io.restest.core.execution.HttpRequestRecord.of(
+                        io.restest.core.model.HttpMethod.GET, "http://localhost:8080/widgets"),
+                new io.restest.core.execution.HttpResponseRecord(
+                        io.restest.core.execution.StatusLine.of(200), List.of(),
+                        java.util.Optional.of(new Payload(content, "text/plain",
+                                java.util.Optional.of(5L)))),
+                Interactions.NOON, Duration.ofMillis(3));
+
+        store.record(stored);
+
+        assertThat(store.find(InteractionQuery.all())).containsExactly(stored);
+    }
+
+    @Test
+    @DisplayName("a large reply survives: the reader's defence against strangers is not aimed at us")
+    void a_large_body_can_be_read_back() {
+        String large = "x".repeat(2_000_000);
+        Interaction stored = Interaction.answered(
+                Interactions.testCase("GET /large"),
+                io.restest.core.execution.HttpRequestRecord.of(
+                        io.restest.core.model.HttpMethod.GET, "http://localhost:8080/large"),
+                new io.restest.core.execution.HttpResponseRecord(
+                        io.restest.core.execution.StatusLine.of(200), List.of(),
+                        java.util.Optional.of(Payload.text(large, "text/plain"))),
+                Interactions.NOON, Duration.ofSeconds(1));
+
+        store.record(stored);
+
+        assertThat(store.find(InteractionQuery.all()).get(0)
+                .response().orElseThrow().body().orElseThrow().size()).isEqualTo(2_000_000);
+    }
+
+    @Test
+    @DisplayName("two runs of the same program store the same interaction identically")
+    void the_stored_shape_does_not_change_between_runs() {
+        Interaction stored = Interactions.elaborate();
+
+        String once = Json.write(InteractionDocument.of(stored));
+        String again = Json.write(InteractionDocument.of(stored));
+
+        assertThat(once)
+                .describedAs("field order comes from the code, not from how a particular run of "
+                        + "the program happened to lay out a map")
+                .isEqualTo(again)
+                .contains("{\"name\":\"Accept\",\"value\":\"application/json\"}")
+                .contains("\"mediaType\":\"application/json\",\"value\":");
+    }
+
+    @Test
+    @DisplayName("ordinary numbers are stored as people write them, not in exponent notation")
+    void numbers_are_stored_readably() {
+        Interaction stored = Interactions.answered("GET /widgets", 500);
+
+        String document = Json.write(InteractionDocument.of(stored));
+
+        assertThat(document)
+                .describedAs("a stored run is meant to be readable by anything that reads JSON, "
+                        + "and 5E+2 is not what anybody expects a status code to look like")
+                .contains("\"status\":500")
+                .doesNotContain("E+");
+    }
+
+    @Test
     @DisplayName("every question the query API can ask")
     void the_queries_answer_what_they_claim() {
         store.record(Interactions.answered("GET /widgets", 200));
@@ -320,6 +441,14 @@ class SqliteInteractionStoreTest {
                 .describedAs("the facts people filter on are plain columns, so SQL can be used "
                         + "directly against a stored run")
                 .containsExactly("POST /widgets");
+    }
+
+    private static void execute(Path file, String sql) throws Exception {
+        org.sqlite.SQLiteDataSource source = new org.sqlite.SQLiteDataSource();
+        source.setUrl("jdbc:sqlite:" + file.toAbsolutePath());
+        try (var connection = source.getConnection(); var statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
     }
 
     private static List<String> readColumn(Path file, String sql) throws Exception {

--- a/restest-store/src/test/java/io/restest/store/SqliteInteractionStoreTest.java
+++ b/restest-store/src/test/java/io/restest/store/SqliteInteractionStoreTest.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2026 ISA Research Group, Universidad de Sevilla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.restest.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.restest.core.execution.Interaction;
+import io.restest.core.execution.InteractionId;
+import io.restest.core.execution.InteractionOutcome;
+import io.restest.core.execution.Payload;
+import io.restest.core.model.OperationId;
+import io.restest.core.store.InteractionQuery;
+import io.restest.core.store.InteractionStoreException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * What the store promises: whatever a run did is still there afterwards, exactly as it happened, and
+ * can be asked about.
+ */
+class SqliteInteractionStoreTest {
+
+    @TempDir
+    Path directory;
+
+    private SqliteInteractionStore store;
+
+    @BeforeEach
+    void openAStore() {
+        store = SqliteInteractionStore.inMemory();
+    }
+
+    @AfterEach
+    void closeTheStore() {
+        store.close();
+    }
+
+    @Test
+    @DisplayName("everything about an interaction comes back exactly as it went in")
+    void an_interaction_survives_the_round_trip() {
+        Interaction stored = Interactions.elaborate();
+
+        store.record(stored);
+
+        assertThat(store.find(InteractionQuery.all()))
+                .describedAs("records are values: what comes back should equal what went in, "
+                        + "component for component, with no special reading required")
+                .containsExactly(stored);
+    }
+
+    @Test
+    @DisplayName("a repeated header stays repeated, and in the order it arrived")
+    void repeated_headers_survive() {
+        store.record(Interactions.elaborate());
+
+        Interaction read = store.find(InteractionQuery.all()).get(0);
+
+        assertThat(read.response().orElseThrow().headerValues("Set-Cookie"))
+                .containsExactly("a=1", "b=2");
+        assertThat(read.request().headerValues("Accept"))
+                .containsExactly("application/json", "text/plain");
+    }
+
+    @Test
+    @DisplayName("a reply too big to keep still remembers how big it was")
+    void a_truncated_body_keeps_its_real_length() {
+        store.record(Interactions.elaborate());
+
+        Payload body = store.find(InteractionQuery.all()).get(0)
+                .response().orElseThrow().body().orElseThrow();
+
+        assertThat(body.truncated()).isTrue();
+        assertThat(body.deliveredLength()).isEqualTo(4096);
+        assertThat(new String(body.content(), StandardCharsets.UTF_8)).isEqualTo("{\"id\":\"w-1\"");
+    }
+
+    @Test
+    @DisplayName("a reply that is not text at all comes back byte for byte")
+    void a_binary_body_is_not_mangled() {
+        Interaction stored = Interactions.withBinaryReply();
+
+        store.record(stored);
+
+        assertThat(store.find(InteractionQuery.all())).containsExactly(stored);
+    }
+
+    @Test
+    @DisplayName("where every value came from is still there, which is what explains a run later")
+    void the_provenance_of_every_value_survives() {
+        store.record(Interactions.elaborate());
+
+        Interaction read = store.find(InteractionQuery.all()).get(0);
+
+        assertThat(read.testCase().parameterValues()).hasSize(3);
+        assertThat(read.testCase().parameterValues().get(2).origin())
+                .isInstanceOf(io.restest.core.execution.ValueOrigin.Derived.class);
+        assertThat(read.testCase().body()).isPresent();
+        assertThat(read.testCase()).isEqualTo(Interactions.elaborate().testCase());
+    }
+
+    @Test
+    @DisplayName("an attempt that never got an answer is stored as one, not lost")
+    void a_failed_attempt_survives() {
+        Interaction failed = Interactions.failed("GET /widgets");
+
+        store.record(failed);
+
+        Interaction read = store.find(InteractionQuery.all()).get(0);
+        assertThat(read).isEqualTo(failed);
+        assertThat(read.outcome()).isInstanceOf(InteractionOutcome.TransportFailure.class);
+    }
+
+    @Test
+    @DisplayName("a reply that stopped halfway keeps its status, its headers and the part that came")
+    void a_malformed_reply_survives() {
+        Interaction malformed = Interactions.malformed("GET /widgets", 200);
+
+        store.record(malformed);
+
+        Interaction read = store.find(InteractionQuery.all()).get(0);
+        assertThat(read).isEqualTo(malformed);
+        InteractionOutcome.MalformedResponse outcome =
+                (InteractionOutcome.MalformedResponse) read.outcome();
+        assertThat(outcome.statusLine().orElseThrow().statusCode()).isEqualTo(200);
+        assertThat(outcome.partial().orElseThrow().deliveredLength()).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("interactions come back oldest first, whatever order they were written in")
+    void interactions_come_back_in_the_order_they_happened() {
+        Interaction later = Interactions.answered("GET /b", 200,
+                Interactions.NOON.plus(Duration.ofSeconds(10)));
+        Interaction earlier = Interactions.answered("GET /a", 200, Interactions.NOON);
+
+        store.record(later);
+        store.record(earlier);
+
+        assertThat(store.find(InteractionQuery.all()))
+                .containsExactly(earlier, later);
+    }
+
+    @Test
+    @DisplayName("every question the query API can ask")
+    void the_queries_answer_what_they_claim() {
+        store.record(Interactions.answered("GET /widgets", 200));
+        store.record(Interactions.answered("GET /widgets", 500));
+        store.record(Interactions.answered("POST /widgets", 201));
+        store.record(Interactions.answered("POST /widgets", 503));
+        store.record(Interactions.failed("GET /gone"));
+        store.record(Interactions.malformed("GET /half", 200));
+
+        assertThat(store.count(InteractionQuery.all())).isEqualTo(6);
+        assertThat(store.count(InteractionQuery.forOperation(OperationId.of("GET /widgets"))))
+                .isEqualTo(2);
+        assertThat(store.count(InteractionQuery.withStatus(503))).isEqualTo(1);
+        assertThat(store.count(InteractionQuery.serverErrors()))
+                .describedAs("500 and 503, and nothing that merely failed to connect")
+                .isEqualTo(2);
+        assertThat(store.count(InteractionQuery.neverAnswered())).isEqualTo(1);
+        assertThat(store.count(InteractionQuery.all()
+                .andOutcome(InteractionQuery.Outcome.MALFORMED))).isEqualTo(1);
+        assertThat(store.count(InteractionQuery.forOperation(OperationId.of("POST /widgets"))
+                .andStatusClass(5))).isEqualTo(1);
+        assertThat(store.count(InteractionQuery.forOperation(OperationId.of("GET /nothing"))))
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("a limit is about how many you want back, not about how many there are")
+    void a_limit_caps_the_answer_but_not_the_count() {
+        IntStream.range(0, 10).forEach(i -> store.record(Interactions.answered("GET /widgets", 200,
+                Interactions.NOON.plusSeconds(i))));
+
+        assertThat(store.find(InteractionQuery.all().limitedTo(3))).hasSize(3);
+        assertThat(store.count(InteractionQuery.all().limitedTo(3))).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("one interaction can be found again by its identifier")
+    void an_interaction_can_be_found_by_id() {
+        Interaction stored = Interactions.elaborate();
+        store.record(stored);
+
+        assertThat(store.byId(stored.id())).contains(stored);
+        assertThat(store.byId(InteractionId.of("never-happened"))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("recording the same interaction twice leaves one, not two")
+    void recording_the_same_interaction_twice_is_harmless() {
+        Interaction stored = Interactions.elaborate();
+
+        store.record(stored);
+        store.record(stored);
+
+        assertThat(store.count(InteractionQuery.all())).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("a run closed and reopened is all still there, which is the point of storing it")
+    void a_stored_run_outlives_the_program_that_made_it() {
+        Path file = directory.resolve("run.sqlite");
+        Interaction stored = Interactions.elaborate();
+
+        try (SqliteInteractionStore writing = SqliteInteractionStore.at(file)) {
+            writing.record(stored);
+            writing.record(Interactions.failed("GET /gone"));
+        }
+
+        try (SqliteInteractionStore reading = SqliteInteractionStore.at(file)) {
+            assertThat(reading.count(InteractionQuery.all())).isEqualTo(2);
+            assertThat(reading.byId(stored.id())).contains(stored);
+        }
+    }
+
+    @Test
+    @DisplayName("two runs open at once do not see each other")
+    void two_stores_keep_separate_runs() {
+        try (SqliteInteractionStore other = SqliteInteractionStore.at(directory.resolve("b.db"))) {
+            store.record(Interactions.answered("GET /a", 200));
+            other.record(Interactions.answered("GET /b", 200));
+            other.record(Interactions.answered("GET /c", 200));
+
+            assertThat(store.count(InteractionQuery.all())).isEqualTo(1);
+            assertThat(other.count(InteractionQuery.all())).isEqualTo(2);
+        }
+    }
+
+    @Test
+    @DisplayName("recording from many threads at once loses nothing")
+    void recording_from_many_threads_loses_nothing() throws InterruptedException {
+        int writers = 8;
+        int each = 25;
+        CountDownLatch done = new CountDownLatch(writers);
+
+        for (int writer = 0; writer < writers; writer++) {
+            Thread.ofVirtual().start(() -> {
+                try {
+                    for (int i = 0; i < each; i++) {
+                        store.record(Interactions.answered("GET /widgets", 200));
+                    }
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+        assertThat(store.count(InteractionQuery.all())).isEqualTo((long) writers * each);
+    }
+
+    @Test
+    @DisplayName("a closed store says so instead of failing obscurely, and closing twice is fine")
+    void a_closed_store_refuses_to_be_used() {
+        SqliteInteractionStore closed = SqliteInteractionStore.at(directory.resolve("closed.db"));
+        closed.close();
+        closed.close();
+
+        assertThatExceptionOfType(InteractionStoreException.class)
+                .isThrownBy(() -> closed.count(InteractionQuery.all()))
+                .withMessageContaining("closed");
+    }
+
+    @Test
+    @DisplayName("a store that cannot be opened says where and why")
+    void an_unusable_location_is_reported() {
+        Path insideAFile = directory.resolve("not-a-directory").resolve("run.db");
+
+        assertThatExceptionOfType(InteractionStoreException.class)
+                .isThrownBy(() -> SqliteInteractionStore.at(insideAFile))
+                .withMessageContaining("run.db");
+    }
+
+    @Test
+    @DisplayName("the file is an ordinary SQLite database, readable without RESTest")
+    void the_stored_run_is_readable_by_anything_that_reads_sqlite() throws Exception {
+        Path file = directory.resolve("run.sqlite");
+        try (SqliteInteractionStore writing = SqliteInteractionStore.at(file)) {
+            writing.record(Interactions.elaborate());
+        }
+
+        assertThat(Files.readAllBytes(file))
+                .describedAs("every SQLite file starts by saying so")
+                .startsWith("SQLite format 3".getBytes(StandardCharsets.US_ASCII));
+
+        List<String> documents = readColumn(file, "SELECT document FROM interaction");
+        assertThat(documents).hasSize(1);
+        assertThat(documents.get(0))
+                .describedAs("the interaction is stored as JSON, which is what makes a run "
+                        + "readable by tools that never heard of RESTest")
+                .contains("\"operation\":\"POST /widgets\"")
+                .contains("\"status\":201")
+                .contains("\"name\":\"a widget\"");
+        assertThat(readColumn(file, "SELECT operation FROM interaction"))
+                .describedAs("the facts people filter on are plain columns, so SQL can be used "
+                        + "directly against a stored run")
+                .containsExactly("POST /widgets");
+    }
+
+    private static List<String> readColumn(Path file, String sql) throws Exception {
+        org.sqlite.SQLiteDataSource source = new org.sqlite.SQLiteDataSource();
+        source.setUrl("jdbc:sqlite:" + file.toAbsolutePath());
+        try (var connection = source.getConnection();
+                var statement = connection.createStatement();
+                var rows = statement.executeQuery(sql)) {
+            List<String> values = new java.util.ArrayList<>();
+            while (rows.next()) {
+                values.add(rows.getString(1));
+            }
+            return values;
+        }
+    }
+}


### PR DESCRIPTION
**Increment:** 1.4, from `ROADMAP.md`

## What you can do now that you could not before

A run's evidence used to live only in memory: the engine produced interactions, handed them back, and
when the program ended they were gone. Now a run is **one SQLite file** that outlives it — every
request as it was sent, every reply as it came back, how long each took, which test it belonged to and
where every value in it came from — and it can be asked questions afterwards ("which of these returned
a server error?") from an index rather than by reading the whole run back into memory. The file is
readable by anything that reads SQLite, so the evidence is not locked inside our reports.

Nothing writes to it automatically yet: the engine is handed interactions by the caller, and wiring
the store to the event stream is **M1.6**, with the command line at **M1.7**. Until then it is used
from Java, which is what the demonstration below does.

## Try it yourself

Only Java 21+ and git needed (`sqlite3` for the last step, which ships with macOS and most Linuxes).

```
git clone https://github.com/isa-group/RESTest.git && cd RESTest
git switch feat/m1-4-interaction-store
./mvnw -q install -DskipTests
./mvnw -q dependency:build-classpath -pl restest-store -Dmdep.outputFile=/tmp/cp.txt -Dmdep.includeScope=runtime
```

This sends fifteen requests to the public Swagger Petstore with M1.3's engine, stores each one, closes
the file, reopens it and asks it questions:

```
cat > /tmp/demo.jsh <<'EOF'
import io.restest.core.execution.*; import io.restest.core.model.*; import io.restest.core.store.*; import io.restest.exec.OkHttpEngine; import io.restest.store.*; import java.nio.file.*; import java.util.*;
var file = Paths.get("run.sqlite").toAbsolutePath();
Files.deleteIfExists(file);
var store = SqliteInteractionStore.at(file);
var engine = new OkHttpEngine();
var base = "https://petstore3.swagger.io/api/v3";
record Call(String operation, String url) {}
var calls = List.of(new Call("GET /pet/findByStatus", base + "/pet/findByStatus?status=available"), new Call("GET /pet/{petId}", base + "/pet/999999999"), new Call("GET /store/inventory", base + "/store/inventory"));
for (var call : calls) { for (int i = 0; i < 5; i++) { store.record(engine.send(TestCase.of(OperationId.of(call.operation()), List.of()), HttpRequestRecord.of(HttpMethod.GET, call.url()))); } }
engine.close();
System.out.println("stored " + store.count(InteractionQuery.all()) + " interactions");
store.close();
var reopened = SqliteInteractionStore.at(file);
System.out.println("after reopening: " + reopened.count(InteractionQuery.all()) + " interactions");
System.out.println("  answered 404: " + reopened.count(InteractionQuery.withStatus(404)));
System.out.println("  server errors: " + reopened.count(InteractionQuery.serverErrors()));
System.out.println("  never answered: " + reopened.count(InteractionQuery.neverAnswered()));
var one = reopened.find(InteractionQuery.forOperation(OperationId.of("GET /pet/{petId}")).limitedTo(1)).get(0);
System.out.println("first attempt at GET /pet/{petId}: " + one.response().map(r -> r.statusCode()).orElse(0) + " after " + one.elapsed().toMillis() + " ms");
reopened.close();
System.out.println("file: " + (Files.size(file)/1024) + " KiB");
EOF
```

```
jshell -q --class-path "restest-store/target/classes:restest-exec/target/classes:$(cat /tmp/cp.txt)" /tmp/demo.jsh
```

Real output from this branch, just now:

```
stored 15 interactions
after reopening: 15 interactions
  answered 404: 5
  server errors: 5
  never answered: 0
first attempt at GET /pet/{petId}: 404 after 122 ms
file: 356 KiB
```

Now the point of the whole increment — the evidence is readable **without RESTest**:

```
sqlite3 run.sqlite "SELECT operation, status_code, COUNT(*) FROM interaction GROUP BY operation, status_code;"
```

```
GET /pet/findByStatus|200|5
GET /pet/{petId}|404|5
GET /store/inventory|500|5
```

(The Petstore really does answer `500` to `GET /store/inventory` today. That is the sort of thing this
file exists to keep.) And the interaction itself is stored as JSON beside those columns, so SQLite's
own JSON functions work on it:

```
sqlite3 run.sqlite "SELECT json_extract(document, '\$.outcome.status'), substr(document, 1, 96) FROM interaction LIMIT 1;"
```

```
200|{"id":"91c7e180-fe90-49d4-b125-2f02549c9baa","sentAt":"2026-09-12T19:41:59.770177Z","elapsed":
```

No internet? The tests cover the same ground against interactions built by hand:

```
./mvnw -q verify -pl restest-store
```

## How it works

One run is one file, and one interaction is one row in it. The row has a column for each of the few
facts anybody filters on — which operation, which status code, how it ended, when it went out — and
each of those has an index, which is why "how many server errors were there" is answered instantly
even in a run of a hundred thousand requests instead of by rebuilding all hundred thousand in memory.

Beside those columns sits the interaction itself, written as a JSON document. That has two payoffs.
The stored run is readable by anything that reads JSON, without RESTest and without knowing our
database layout. And adding a field to what RESTest records does not mean a new column and a migration
for every run anybody has ever stored.

```
  interaction
  ┌──────────┬──────────────────────┬─────────────┬─────────┬──────────────────────────┐
  │ id       │ operation            │ status_code │ outcome │ document                 │
  ├──────────┼──────────────────────┼─────────────┼─────────┼──────────────────────────┤
  │ 91c7e180 │ GET /pet/findByStatus│         200 │ answered│ {"id":"91c7e180", …}     │
  │ a3f1…    │ GET /pet/{petId}     │         404 │ answered│ {"id":"a3f1…", …}        │
  │ c80b…    │ GET /store/inventory │         500 │ answered│ {"id":"c80b…", …}        │
  └──────────┴──────────────────────┴─────────────┴─────────┴──────────────────────────┘
      indexed, for the questions          ↑                        the whole truth,
      people actually ask ────────────────┘                        for everything else
```

Bodies get whichever treatment keeps them honest: a reply whose bytes are valid text is stored as that
text, so a JSON reply in a stored run looks like a JSON reply; one that is not — an image, a reply that
arrived mangled — is stored as base64, so nothing is quietly altered on the way in. A reply too big to
keep whole is stored in part while still recording how big it really was.

## What changed in the code

**`restest-core`, new package `io.restest.core.store`** (named after the module that implements it, as
`io.restest.core.spec` and `io.restest.core.exec` already are):

- `InteractionStore` — `record`, `find`, `count`, `byId`, `close`. Safe from several threads.
- `InteractionQuery` — a small record of filters with factories named after the questions people ask:
  `all()`, `forOperation(…)`, `withStatus(404)`, `serverErrors()`, `neverAnswered()`, `limitedTo(n)`.
- `InteractionStoreException` — the one thing in RESTest that throws, because a run whose evidence is
  being silently dropped is producing nothing of value.

**`restest-store`:** `SqliteInteractionStore` (one file per run, the schema above, `PRAGMA
user_version` stamped so a run from a newer RESTest says so plainly); `InteractionDocument`
(`Interaction` ↔ `JsonValue` — the one serialised shape in the project); `Json` (`JsonValue` ↔ text,
over `jackson-core`'s streaming reader and writer).

**Elsewhere:** `sqlite-jdbc` 3.50.3.0 and `jackson-core` 2.22.1 in the root POM and in the stack table;
a new architecture rule confining both to `restest-store`, matching the ones that confine the OpenAPI
parser to `restest-spec` and the HTTP client to `restest-exec`; ADR-0006 amended; `ROADMAP.md` marks
1.4.

**Left for later, deliberately:** wiring the store to the event stream so a run persists itself (M1.6);
`restest recheck` and `CorpusOracle` (M3.3); the NDJSON report (M3.5); run-level metadata — which
specification, which base URL, which budget — which belongs with the command line that knows those
things (M1.7); paged or streaming queries, which the first consumer that needs them should shape.

## Evidence

- [x] Tests: **48 added** (4 in `restest-core`, 44 in `restest-store`), all green — `./mvnw clean
      verify` passes in full locally; CI on this pull request is the link of record.
- [x] Architecture tests: **1 added** (`org.sqlite` and `com.fasterxml` confined to `restest-store`) —
      none weakened. All seven rules and the seven self-tests green.
- [x] Mutation score: **not applicable** — no oracle or constraint code touched.
- [x] Per-request overhead: **71 µs per interaction written** (10,000 interactions in 710 ms), against
      a network request measured in hundreds of milliseconds. Counting 10,000 rows: 37 ms. Reading 100
      back: 62 ms. A 10,000-interaction run with a small JSON reply each: 7.5 MB.
- [x] Smoke run, two containerised APIs: **not applicable** — arrives with the command line at M1.7.
- [x] Idle time: **not applicable** — this increment sends nothing.
- [x] Artefact: the terminal transcript under "Try it yourself", including the `sqlite3` output,
      produced by this branch against the live Petstore.

## Decisions taken

**One store, not two — SQLite only.** Agreed with the maintainer before any code was written, and
recorded as an amendment to ADR-0006, which had said "SQLite by default, NDJSON as an alternative".
The two would have done the same job behind the same interface rather than complementing each other,
and NDJSON already appears in the roadmap at M3.5 among the report formats, which is what design
principle 8 actually asks for. They are also not equally good at the job: everything downstream asks
the store questions repeatedly, and a plain-text file answers them by parsing itself from the
beginning every time. This is the same trade ADR-0007 made at M1.2 when it went back to one parser
backend, for the reason stated there.

**The consequence, named rather than buried:** the tool now depends on a database driver carrying
native libraries, so the GraalVM native binary at M7.3 will need configuration for it. Routine, and
recorded in the ADR so M7.3 does not meet it as a surprise.

**Indexed columns plus a JSON document, rather than a fully normalised schema.** Fewer moving parts,
no migration when the model gains a field, and it keeps the stored run readable by anything that reads
JSON. The cost is that a question the columns do not cover needs SQLite's JSON functions rather than a
plain join.

**A damaged interaction fails loudly, rather than being skipped.** Design principle 2 says a bad
*specification* must never stop a run; a stored run that has been corrupted is a different matter, and
quietly dropping evidence would be the worst behaviour available to the component whose whole job is
to be the surviving evidence. The failure now names the row so it can be excluded deliberately.

**Nine reviewer findings acted on**, each with a test that would have caught it:

- `find` returned interactions in an order that could be exactly reversed — the moment a request went
  out was compared as written text, and an instant prints however many decimals it needs, so
  `12:00:00Z` sorted *after* `12:00:00.5Z`. Ordering is now by a count of nanoseconds. The old test
  used timestamps two whole seconds apart, the one case where the bug cannot appear; the new one uses
  fractions of a second.
- Every status code of 200 or 500 was stored as `2E+2` and `5E+2` — the same number, and not what
  anybody reading a stored run expects. The old test asserted on `201`, one of the few codes with no
  trailing zero, so it passed while the claim it defended was false.
- Two runs of the same program stored the same interaction with its fields in different orders, because
  two small maps were built in a way whose iteration order the JVM scrambles per run.
- A reply that named its length without having been cut short lost that length on the way back — a hole
  in the exact round-trip property the increment rests on.
- A reply larger than 20 MB was written happily and could then never be read: the JSON reader's default
  defence against hostile input was being applied to a file this tool had written itself moments
  earlier.
- A store that failed while creating its tables leaked its connection.
- A corrupt document threw `DateTimeParseException` and friends at a caller the interface promises
  only ever sees `InteractionStoreException`.
- There was no schema version stamp, which cannot be retrofitted onto runs already on disk.
- Reading held the lock while rebuilding every interaction, so recording what an API had just answered
  waited for somebody else's query.

**One finding partly acted on, and stated rather than papered over.** The review pointed out that the
amendment's justification — "M3.5's NDJSON report is the stored document written out" — is not true as
the code stands, because `restest-report` may not depend on `restest-store` under the current layer
rules. The amendment now says exactly that, and names the two ways M3.5 can make it true: take that
dependency deliberately, or move the document shape into `restest-core`, which can hold it without
gaining a JSON library. The decision belongs to M3.5, with the requirement recorded here that no second
interaction-to-JSON mapping gets written.

**WAL mode kept, and the class comment corrected instead.** Writing in this mode lets somebody read a
run while it is still going on, at the price of two working files beside the main one until the store is
closed. The Javadoc claimed "one file" unconditionally; it now says plainly that an interrupted run
leaves three files and that all three are the evidence.

## Open questions

**None.** Row 1.4 of `ROADMAP.md` is ticked with this pull request's number, per the convention M1.3
introduced, and the row's wording is updated to match the scope decided above.

---

- [x] Targets `v2`, not `main`
- [x] English throughout, including comments and test names
- [x] Nothing from the deferred backlog ("Out of scope for v2.0" in `docs/DESIGN.md`)
- [x] No AI abstraction; no benchmark-platform reference under `src/`
- [x] Reviewed by the `reviewer` subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
